### PR TITLE
Develop

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -165,7 +165,9 @@
       'sources': [
         'src/binding.cc',
         'src/peerconnection.cc',
-        'src/datachannel.cc'
+        'src/datachannel.cc',
+        'src/mediastream.cc',
+        'src/mediastreamtrack.cc'
       ]
     }
   ]

--- a/index.js
+++ b/index.js
@@ -2,3 +2,5 @@ exports.RTCIceCandidate = require('./icecandidate');
 exports.RTCSessionDescription = require('./sessiondescription');
 exports.RTCPeerConnection = require('./peerconnection');
 exports.RTCDataChannel = require('./datachannel');
+exports.RTCMediaStream = require('./mediastream');
+exports.RTCMediaStreamTrack = require('./mediastreamtrack');

--- a/mediastream.js
+++ b/mediastream.js
@@ -1,0 +1,223 @@
+var RTCMediaStreamTrack = require('./mediastreamtrack');
+
+function MediaStream(internalMS) {
+  var that = this;
+  this._ms = internalMS;
+
+  this._queue = [];
+  this._pending = null;
+    
+  this._ms.onactive = function onactive() {
+    if(that.onactive && typeof that.onactive == 'function') {
+      that.onactive.apply(that, []);
+    }
+  };
+    
+  this._ms.oninactive = function oninactive() {
+    if(that.oninactive && typeof that.oninactive == 'function') {
+      that.oninactive.apply(that, []);
+    }
+  };
+    
+  this._ms.onaddtrack = function onaddtrack(internalMST) {
+    if(that.onaddtrack && typeof that.onaddtrack == 'function') {
+      var mst = new RTCMediaStreamTrack(internalMST);
+      that.onaddtrack.apply(that, [mst]);
+    }
+  };
+    
+  this._ms.onremovetrack = function onremovetrack(internalMST) {
+    if(that.onremovetrack && typeof that.onremovetrack == 'function') {
+      var mst = new RTCMediaStreamTrack(internalMST);
+      that.onremovetrack.apply(that, [mst]);
+    }
+  };
+
+  this.onactive = null;
+  this.oninactive = null;
+  this.onaddtrack = null;
+  this.onremovetrack = null;
+}
+
+module.exports = MediaStream;
+
+MediaStream.prototype._getMS = function _getMS() {
+  if(!this._ms) {
+    throw new Error('RTCMediaSteam is gone');
+  }
+  return this._ms;
+};
+
+MediaStream.prototype._queueOrRun = function _queueOrRun(obj) {
+  var ms = this._getMS();
+  if(null == this._pending) {
+    ms[obj.func].apply(ms, obj.args);
+    if(obj.wait) {
+      this._pending = obj;
+    }
+  } else {
+    this._queue.push(obj);
+  }
+};
+
+MediaStream.prototype._executeNext = function _executeNext() {
+  var obj, ms;
+  ms = this._getMS();
+  if(this._queue.length > 0) {
+    obj = this._queue.shift();
+    ms[obj.func].apply(ms, obj.args);
+    if(obj.wait)
+    {
+      this._pending = obj;
+    } else {
+      this._executeNext();
+    }
+  } else {
+    this._pending = null;
+  }
+};
+
+MediaStream.prototype.getId = function getId() {
+  return this._getMS().id;
+};
+
+MediaStream.prototype.isInactive = function isInactive() {
+  return this._getMS().inactive;
+};
+
+MediaStream.prototype.getaudiotracks = function getaudiotracks() {
+  return this._getMS().getaudiotracks();
+};
+
+MediaStream.prototype.getvideotracks = function getvideotracks() {
+  return this._getMS().getvideotracks();
+};
+
+MediaStream.prototype.gettrackbyid = function gettrackbyid(id) {
+  return this._getMS().gettrackbyid(id);
+};
+
+MediaStream.prototype.addtrack = function addtrack(track) {
+  this._getMS().addtrack(track);
+};
+
+MediaStream.prototype.removetrack = function removetrack(track) {
+  this._getMS().removetrack(track);
+};
+
+// FIXME: implement clone
+/*MediaStream.prototype.clone = function clone() {
+  return this._getMS().clone();
+};*/
+
+MediaStream.prototype.getOnActive = function() {
+  return this.onactive;
+};
+
+MediaStream.prototype.setOnActive = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onactive = cb;
+};
+
+MediaStream.prototype.getOnInactive = function() {
+  return this.oninactive;
+};
+
+MediaStream.prototype.setOnInactive = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.oninactive = cb;
+};
+
+MediaStream.prototype.getOnAddTrack = function() {
+  return this.onaddtrack;
+};
+
+MediaStream.prototype.setOnAddTrack = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onaddtrack = cb;
+};
+
+MediaStream.prototype.getOnRemoveTrack = function() {
+  return this.onremovetrack;
+};
+
+MediaStream.prototype.setOnRemoveTrack = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onremovetrack = cb;
+};
+
+function RTCMediaStream(internalMS) {
+  var ms = new MediaStream(internalMS);
+
+  Object.defineProperties(this, {
+    'id': {
+      get: function getId() {
+        return ms.getId();
+      }
+    },
+    'inactive': {
+      get: function isInactive() {
+        return ms.isInactive();
+      }
+    },
+    'onaddtrack': {
+      get: function() {
+        return ms.getOnAddTrack();
+      },
+      set: function(cb) {
+        ms.setOnAddTrack(cb);
+      }
+    },
+    'onremovetrack': {
+      get: function() {
+        return ms.getOnRemoveTrack();
+      },
+      set: function(cb) {
+        ms.setOnRemoveTrack(cb);
+      }
+    },
+    'onactive': {
+      get: function() {
+        return ms.getOnActive();
+      },
+      set: function(cb) {
+        ms.setOnActive(cb);
+      }
+    },
+    'oninactive': {
+      get: function() {
+        return ms.getOnInactive();
+      },
+      set: function(cb) {
+        ms.setOnInactive(cb);
+      }
+    }
+  });
+
+  this.getaudiotracks = function getaudiotracks() {
+    return ms.getaudiotracks.apply(ms, arguments);
+  };
+
+  this.getvideotracks = function getvideotracks() {
+    return ms.getvideotracks.apply(ms, arguments);
+  };
+
+  this.gettrackbyid = function gettrackbyid() {
+    return ms.gettrackbyid.apply(ms, arguments);
+  };
+
+  this.addtrack = function addtrack() {
+    ms.addtrack.apply(ms, arguments);
+  };
+
+  this.removetrack = function removetrack() {
+    ms.removetrack.apply(ms, arguments);
+  };
+  
+  // FIXME: implement clone
+  /*this.clone = function clone() {
+    return ms.clone.apply(ms, arguments);
+  };*/
+}
+
+module.exports = RTCMediaStream;

--- a/mediastreamtrack.js
+++ b/mediastreamtrack.js
@@ -1,0 +1,258 @@
+function MediaStreamTrack(internalMST) {
+  var that = this;
+  this._mst = internalMST;
+
+  this._queue = [];
+  this._pending = null;
+    
+  this._mst.onmute = function onmute() {
+    if(that.onmute && typeof that.onmute == 'function') {
+      that.onmute.apply(that, []);
+    }
+  };
+    
+  this._mst.onunmute = function onunmute() {
+    if(that.onunmute && typeof that.onunmute == 'function') {
+      that.onunmute.apply(that, []);
+    }
+  };
+    
+  this._mst.onstarted = function onstarted() {
+    if(that.onstarted && typeof that.onstarted == 'function') {
+      that.onstarted.apply(that, []);
+    }
+  };
+    
+  this._mst.onended = function onended() {
+    if(that.onended && typeof that.onended == 'function') {
+      that.onended.apply(that, []);
+    }
+  };
+
+  this.onmute = null;
+  this.onunmute = null;
+  this.onstarted = null;
+  this.onstarted = null;
+}
+
+module.exports = MediaStreamTrack;
+
+MediaStreamTrack.prototype._getMST = function _getMST() {
+  if(!this._mst) {
+    throw new Error('RTCMediaSteamTrack is gone');
+  }
+  return this._mst;
+};
+
+MediaStreamTrack.prototype._queueOrRun = function _queueOrRun(obj) {
+  var mst = this._getMST();
+  if(null == this._pending) {
+    mst[obj.func].apply(mst, obj.args);
+    if(obj.wait) {
+      this._pending = obj;
+    }
+  } else {
+    this._queue.push(obj);
+  }
+};
+
+MediaStreamTrack.prototype._executeNext = function _executeNext() {
+  var obj, mst;
+  mst = this._getMST();
+  if(this._queue.length > 0) {
+    obj = this._queue.shift();
+    mst[obj.func].apply(mst, obj.args);
+    if(obj.wait)
+    {
+      this._pending = obj;
+    } else {
+      this._executeNext();
+    }
+  } else {
+    this._pending = null;
+  }
+};
+
+MediaStreamTrack.prototype.RTCMediaStreamTrackStates = [
+  'initializing',
+  'live',
+  'ended',
+  'failed'
+];
+
+MediaStreamTrack.prototype.getId = function getId() {
+  return this._getMST().id;
+};
+
+MediaStreamTrack.prototype.getKind = function getKind() {
+  return this._getMST().kind;
+};
+
+MediaStreamTrack.prototype.getLabel = function getLabel() {
+  return this._getMST().label;
+};
+
+MediaStreamTrack.prototype.getEnabled = function getEnabled() {
+  return this._getMST().enabled;
+};
+
+MediaStreamTrack.prototype.setEnabled = function setEnabled(enable) {
+  this._getMST().enabled = enable;
+};
+
+MediaStreamTrack.prototype.getMuted = function getMuted() {
+  return this._getMST().muted;
+};
+
+MediaStreamTrack.prototype.getReadOnly = function getReadOnly() {
+  return this._getMST()._readonly;
+};
+
+MediaStreamTrack.prototype.getRemote = function getRemote() {
+  return this._getMST().remote;
+};
+
+MediaStreamTrack.prototype.getReadyState = function getReadyState() {
+  var state = this._getMST().readyState;
+  return this.RTCMediaStreamTrackStates[state];
+};
+
+// FIXME: implement stop
+/*MediaStreamTrack.prototype.stop = function stop() {
+  return this._getMST().stop();
+};*/
+
+// FIXME: implement clone
+/*MediaStreamTrack.prototype.clone = function clone() {
+  return this._getMST().clone();
+};*/
+
+MediaStreamTrack.prototype.getOnStarted = function() {
+  return this.onstarted;
+};
+
+MediaStreamTrack.prototype.setOnStarted = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onstarted = cb;
+};
+
+MediaStreamTrack.prototype.getOnEnded = function() {
+  return this.onended;
+};
+
+MediaStreamTrack.prototype.setOnEnded = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onended = cb;
+};
+
+MediaStreamTrack.prototype.getOnMute = function() {
+  return this.onmute;
+};
+
+MediaStreamTrack.prototype.setOnMute = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onmute = cb;
+};
+
+MediaStreamTrack.prototype.getOnUnmute = function() {
+  return this.onunmute;
+};
+
+MediaStreamTrack.prototype.setOnUnmute = function(cb) {
+  // FIXME: throw an exception if cb isn't callable
+  this.onunmute = cb;
+};
+
+function RTCMediaStreamTrack(internalMST) {
+  var mst = new MediaStreamTrack(internalMST);
+  
+  Object.defineProperties(this, {
+    'id': {
+      get: function getId() {
+        return mst.getId();
+      }
+    },
+    'label': {
+      get: function getLabel() {
+        return mst.getLabel();
+      }
+    },
+    'kind': {
+      get: function getKind() {
+        return mst.getKind();
+      }
+    },
+    'enabled': {
+      get: function getEnabled() {
+        return mst.getEnabled();
+      },
+      set: function setEnabled(enable) {
+        mst.setEnabled(enable);
+      }
+    },
+    'muted': {
+      get: function getMuted() {
+        return mst.getMuted();
+      }
+    },
+    '_readonly': {
+      get: function getReadOnly() {
+        return mst.getReadOnly();
+      }
+    },
+    'remote': {
+      get: function getRemote() {
+        return mst.getRemote();
+      }
+    },
+    'readyState': {
+      get: function getReadyState() {
+        return mst.getReadyState();
+      }
+    },
+    'onstarted': {
+      get: function() {
+        return mst.getOnStarted();
+      },
+      set: function(cb) {
+        mst.setOnStarted(cb);
+      }
+    },
+    'onended': {
+      get: function() {
+        return mst.getOnEnded();
+      },
+      set: function(cb) {
+        mst.setOnEnded(cb);
+      }
+    },
+    'onmute': {
+      get: function() {
+        return mst.getOnMute();
+      },
+      set: function(cb) {
+        mst.setOnMute(cb);
+      }
+    },
+    'onunmute': {
+      get: function() {
+        return mst.getOnUnmute();
+      },
+      set: function(cb) {
+        mst.setOnUnmute(cb);
+      }
+    }
+  });
+  
+  // FIXME: implement stop
+  /*this.stop = function stop() {
+    return mst.stop.apply(mst, arguments);
+  };*/
+
+  // FIXME: implement clone
+  /*this.clone = function clone() {
+    return mst.clone.apply(mst, arguments);
+  };*/
+}
+
+module.exports = RTCMediaStreamTrack;

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -5,6 +5,8 @@
 
 #include "peerconnection.h"
 #include "datachannel.h"
+#include "mediastream.h"
+#include "mediastreamtrack.h"
 
 using namespace v8;
 
@@ -12,6 +14,8 @@ void init(Handle<Object> exports) {
   talk_base::InitializeSSL();
   PeerConnection::Init(exports);
   DataChannel::Init(exports);
+  MediaStream::Init(exports);
+  MediaStreamTrack::Init(exports);
 }
 
 NODE_MODULE(webrtc, init)

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -1,0 +1,339 @@
+#include <node_buffer.h>
+
+#include <stdint.h>
+#include <iostream>
+#include <string>
+
+#include "talk/app/webrtc/jsep.h"
+#include "webrtc/system_wrappers/interface/ref_count.h"
+
+#include "common.h"
+#include "mediastream.h"
+#include "mediastreamtrack.h"
+
+using namespace node;
+using namespace v8;
+
+Persistent<Function> MediaStream::constructor;
+
+MediaStream::MediaStream(webrtc::MediaStreamInterface* msi)
+: _internalMediaStream(msi)
+{
+  msi->Release();
+  _inactive = !IsMediaStreamActive();
+  uv_mutex_init(&lock);
+  uv_async_init(uv_default_loop(), &async, Run);
+
+  async.data = this;
+}
+
+MediaStream::~MediaStream()
+{
+    
+}
+
+NAN_METHOD(MediaStream::New) {
+  TRACE_CALL;
+  NanScope();
+
+  if(!args.IsConstructCall()) {
+    return NanThrowTypeError("Use the new operator to construct the MediaStream.");
+  }
+
+  v8::Local<v8::External> _msi = v8::Local<v8::External>::Cast(args[0]);
+  webrtc::MediaStreamInterface* msi = static_cast<webrtc::MediaStreamInterface*>(_msi->Value());
+
+  MediaStream* obj = new MediaStream(msi);
+  msi->RegisterObserver(obj);
+  obj->Wrap( args.This() );
+
+  TRACE_END;
+  NanReturnValue( args.This() );
+}
+
+void MediaStream::QueueEvent(AsyncEventType type, void* data)
+{
+  TRACE_CALL;
+  AsyncEvent evt;
+  evt.type = type;
+  evt.data = data;
+  uv_mutex_lock(&lock);
+  _events.push(evt);
+  uv_mutex_unlock(&lock);
+
+  uv_async_send(&async);
+  TRACE_END;
+}
+
+void MediaStream::Run(uv_async_t* handle, int status)
+{
+  TRACE_CALL;
+  NanScope();
+  MediaStream* self = static_cast<MediaStream*>(handle->data);
+  v8::Handle<v8::Object> ms = NanObjectWrapHandle(self);
+
+  while(true)
+  {
+    uv_mutex_lock(&self->lock);
+    bool empty = self->_events.empty();
+    if(empty)
+    {
+      uv_mutex_unlock(&self->lock);
+      break;
+    }
+    AsyncEvent evt = self->_events.front();
+    self->_events.pop();
+    uv_mutex_unlock(&self->lock);
+
+    TRACE_U("evt.type", evt.type);
+    if(MediaStream::CHANGE & evt.type)
+    {
+      // find current state and send appropriate events
+      bool inactive = !self->IsMediaStreamActive();
+      if (self->_inactive != inactive)
+      {
+        if (!inactive)
+          evt.type = MediaStream::ACTIVE;
+        else
+          evt.type = MediaStream::INACTIVE;
+        self->_inactive = inactive;
+      }
+    }
+    
+    if(MediaStream::ACTIVE & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onactive")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(ms, 0, argv);
+      }
+    } else if(MediaStream::INACTIVE & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("oninactive")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(ms, 0, argv);
+      }
+    }
+    if(MediaStream::ADDTRACK & evt.type) 
+    {
+      webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
+      v8::Local<v8::Value> cargv[1];
+      cargv[0] = v8::External::New(static_cast<void*>(msti));
+      v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onaddtrack")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[1];
+        argv[0] = mst;
+        callback->Call(ms, 1, argv);
+      }
+    }
+    if(MediaStream::REMOVETRACK & evt.type) 
+    {
+      webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
+      v8::Local<v8::Value> cargv[1];
+      cargv[0] = v8::External::New(static_cast<void*>(msti));
+      v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onremovetrack")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[1];
+        argv[0] = mst;
+        callback->Call(ms, 1, argv);
+      }
+    }
+  }
+  scope.Close(Undefined());
+  TRACE_END;
+}
+
+bool MediaStream::IsMediaStreamActive()
+{
+  webrtc::VideoTrackVector videoTracks = _internalMediaStream->GetVideoTracks();
+  for (webrtc::VideoTrackVector::iterator track = videoTracks.begin(); track != videoTracks.end(); track++)
+  {
+    if ((*track)->state() == webrtc::MediaStreamTrackInterface::kLive)
+      return true;
+  }
+  
+  webrtc::AudioTrackVector audioTracks = _internalMediaStream->GetAudioTracks();
+  for (webrtc::AudioTrackVector::iterator track = audioTracks.begin(); track != audioTracks.end(); track++)
+  {
+    if ((*track)->state() == webrtc::MediaStreamTrackInterface::kLive)
+      return true;
+  }
+  
+  return false;
+}
+
+void MediaStream::OnChanged()
+{
+  TRACE_CALL;
+  QueueEvent(MediaStream::CHANGE, static_cast<void*>(NULL));
+  TRACE_END;
+}
+
+webrtc::MediaStreamInterface* MediaStream::GetInterface() {
+    return _internalMediaStream;
+}
+
+NAN_METHOD(MediaStream::getAudioTracks) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  webrtc::AudioTrackVector audioTracks = self->_internalMediaStream->GetAudioTracks();
+  
+  v8::Local<v8::Array> array = v8::Array::New(audioTracks.size());
+  int index = 0;
+  for (webrtc::AudioTrackVector::iterator track = audioTracks.begin(); track != audioTracks.end(); track++, index++) {
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = v8::External::New(static_cast<void*>(track->get()));
+    array->Set(index, NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv));
+  }
+
+  TRACE_END;
+  NanReturnValue(array);
+}
+
+NAN_METHOD(MediaStream::getVideoTracks) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  webrtc::VideoTrackVector videoTracks = self->_internalMediaStream->GetVideoTracks();
+  
+  v8::Local<v8::Array> array = v8::Array::New(videoTracks.size());
+  int index = 0;
+  for (webrtc::VideoTrackVector::iterator track = videoTracks.begin(); track != videoTracks.end(); track++, index++) {
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = v8::External::New(static_cast<void*>(track->get()));
+    array->Set(index, NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv));
+  }
+
+  TRACE_END;
+  NanReturnValue(array);
+}
+
+NAN_METHOD(MediaStream::getTrackById) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  v8::String::Utf8Value param1(args[0]->ToString());
+  std::string _id = std::string(*param1);
+  
+  talk_base::scoped_refptr<webrtc::MediaStreamTrackInterface> audioTrack = self->_internalMediaStream->FindAudioTrack(_id);
+  talk_base::scoped_refptr<webrtc::MediaStreamTrackInterface> videoTrack = self->_internalMediaStream->FindVideoTrack(_id);
+  
+  talk_base::scoped_refptr<webrtc::MediaStreamTrackInterface> track = audioTrack.get() ? audioTrack : videoTrack;
+  webrtc::MediaStreamTrackInterface* msti = track.get();
+  msti->AddRef();
+
+  v8::Local<v8::Value> cargv[1];
+  cargv[0] = v8::External::New(static_cast<void*>(msti));
+  v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+  
+  TRACE_END;
+  NanReturnValue(mst);
+}
+
+NAN_METHOD(MediaStream::addTrack) {
+  TRACE_CALL;
+  NanScope();
+  
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  MediaStreamTrack* _track = ObjectWrap::Unwrap<MediaStreamTrack>(args[0]->ToObject());
+  
+  if (_track->GetInterface()->kind() == "audio") {
+    self->_internalMediaStream->AddTrack((webrtc::AudioTrackInterface*)_track->GetInterface());
+  } else if (_track->GetInterface()->kind() == "video") {
+    self->_internalMediaStream->AddTrack((webrtc::VideoTrackInterface*)_track->GetInterface());
+  }
+
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_METHOD(MediaStream::removeTrack) {
+  TRACE_CALL;
+  NanScope();
+  
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  MediaStreamTrack* _track = ObjectWrap::Unwrap<MediaStreamTrack>(args[0]->ToObject());
+  
+  if (_track->GetInterface()->kind() == "audio") {
+    self->_internalMediaStream->RemoveTrack((webrtc::AudioTrackInterface*)_track->GetInterface());
+  } else if (_track->GetInterface()->kind() == "video") {
+    self->_internalMediaStream->RemoveTrack((webrtc::VideoTrackInterface*)_track->GetInterface());
+  }
+  
+
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_METHOD(MediaStream::clone) {
+  TRACE_CALL;
+  NanScope();
+
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_GETTER(MediaStream::GetId) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+
+  std::string label = self->_internalMediaStream->label();
+
+  TRACE_END;
+  NanReturnValue(String::New(label.c_str()));
+}
+
+NAN_GETTER(MediaStream::IsInactive) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
+  bool inactive = self->_inactive;
+
+  TRACE_END;
+  NanReturnValue(Boolean::New(inactive));
+}
+
+NAN_SETTER(MediaStream::ReadOnly) {
+  INFO("MediaStream::ReadOnly");
+}
+
+
+void MediaStream::Init( Handle<Object> exports ) {
+  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
+  tpl->SetClassName( String::NewSymbol( "MediaStream" ) );
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getaudiotracks" ),
+    FunctionTemplate::New( getAudioTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getvideotracks" ),
+    FunctionTemplate::New( getVideoTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "gettrackbyid" ),
+    FunctionTemplate::New( getTrackById )->GetFunction() );
+
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "addtrack" ),
+    FunctionTemplate::New( addTrack )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "removetrack" ),
+    FunctionTemplate::New( removeTrack )->GetFunction() );
+    
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "clone" ),
+    FunctionTemplate::New( clone )->GetFunction() );
+
+  tpl->InstanceTemplate()->SetAccessor(String::New("id"), GetId, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("inactive"), IsInactive, ReadOnly);
+
+  NanAssignPersistent(Function, constructor, tpl->GetFunction());
+  exports->Set( String::NewSymbol("MediaStream"), tpl->GetFunction() );
+}

--- a/src/mediastream.h
+++ b/src/mediastream.h
@@ -1,0 +1,89 @@
+#ifndef __MEDIASTREAM_H__
+#define __MEDIASTREAM_H__
+
+#include <queue>
+#include <string>
+
+#include <node.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <uv.h>
+
+#include "talk/app/webrtc/jsep.h"
+#include "talk/app/webrtc/mediastreaminterface.h"
+#include "talk/base/thread.h"
+#include "talk/base/scoped_ptr.h"
+#include "webrtc/system_wrappers/interface/ref_count.h"
+
+#include "common.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+class MediaStream
+: public ObjectWrap,
+  public webrtc::ObserverInterface
+{
+    
+public:
+
+  enum AsyncEventType {
+    ACTIVE = 0x1 << 0, // 1
+    ADDTRACK = 0x1 << 1, // 2
+    INACTIVE = 0x1 << 2, // 4
+    REMOVETRACK = 0x1 << 3, // 8
+    CHANGE = 0x1 << 4, // 16
+  };
+  
+  MediaStream(webrtc::MediaStreamInterface* MediaStream);
+  ~MediaStream();
+  
+  //
+  // ObserverInterface implementation.
+  //
+  
+  void OnChanged();
+  
+  //
+  // Nodejs wrapping.
+  //
+  
+  static void Init( Handle<Object> exports );
+  static Persistent<Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_METHOD(getAudioTracks);
+  static NAN_METHOD(getVideoTracks);
+  static NAN_METHOD(getTrackById);
+  static NAN_METHOD(addTrack);
+  static NAN_METHOD(removeTrack);
+  static NAN_METHOD(clone);
+  
+  static NAN_GETTER(GetId);
+  static NAN_GETTER(IsInactive);
+  
+  static NAN_SETTER(ReadOnly);
+
+  void QueueEvent(MediaStream::AsyncEventType type, void* data);
+  webrtc::MediaStreamInterface* GetInterface();
+  bool IsMediaStreamActive();
+  
+private:
+  static void Run(uv_async_t* handle, int status);
+
+  struct AsyncEvent {
+    AsyncEventType type;
+    void* data;
+  };
+
+  uv_mutex_t lock;
+  uv_async_t async;
+  std::queue<AsyncEvent> _events;
+
+  bool _inactive;
+  
+  talk_base::scoped_refptr<webrtc::MediaStreamInterface> _internalMediaStream;
+};
+
+#endif

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -1,0 +1,282 @@
+#include <node_buffer.h>
+
+#include <stdint.h>
+#include <iostream>
+#include <string>
+
+#include "talk/app/webrtc/jsep.h"
+#include "webrtc/system_wrappers/interface/ref_count.h"
+
+#include "common.h"
+#include "mediastreamtrack.h"
+
+using namespace node;
+using namespace v8;
+
+Persistent<Function> MediaStreamTrack::constructor;
+
+MediaStreamTrack::MediaStreamTrack(webrtc::MediaStreamTrackInterface* msti)
+: _internalMediaStreamTrack(msti)
+{
+  msti->Release();
+  _muted = false;
+  _live = _internalMediaStreamTrack->state() == webrtc::MediaStreamTrackInterface::kLive;
+  uv_mutex_init(&lock);
+  uv_async_init(uv_default_loop(), &async, Run);
+
+  async.data = this;
+}
+
+MediaStreamTrack::~MediaStreamTrack()
+{
+    
+}
+
+NAN_METHOD(MediaStreamTrack::New) {
+  TRACE_CALL;
+  NanScope();
+
+  if(!args.IsConstructCall()) {
+    return NanThrowTypeError("Use the new operator to construct the MediaStreamTrack.");
+  }
+
+  v8::Local<v8::External> _msti = v8::Local<v8::External>::Cast(args[0]);
+  webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(_msti->Value());
+
+  MediaStreamTrack* obj = new MediaStreamTrack(msti);
+  msti->RegisterObserver(obj);
+  obj->Wrap( args.This() );
+
+  TRACE_END;
+  NanReturnValue( args.This() );
+}
+
+void MediaStreamTrack::QueueEvent(AsyncEventType type, void* data)
+{
+  TRACE_CALL;
+  AsyncEvent evt;
+  evt.type = type;
+  evt.data = data;
+  uv_mutex_lock(&lock);
+  _events.push(evt);
+  uv_mutex_unlock(&lock);
+
+  uv_async_send(&async);
+  TRACE_END;
+}
+
+void MediaStreamTrack::Run(uv_async_t* handle, int status)
+{
+  TRACE_CALL;
+  NanScope();
+  MediaStreamTrack* self = static_cast<MediaStreamTrack*>(handle->data);
+  v8::Handle<v8::Object> mst = NanObjectWrapHandle(self);
+
+  while(true)
+  {
+    uv_mutex_lock(&self->lock);
+    bool empty = self->_events.empty();
+    if(empty)
+    {
+      uv_mutex_unlock(&self->lock);
+      break;
+    }
+    AsyncEvent evt = self->_events.front();
+    self->_events.pop();
+    uv_mutex_unlock(&self->lock);
+
+    TRACE_U("evt.type", evt.type);
+    if(MediaStreamTrack::CHANGE & evt.type)
+    {
+      // find current state and send appropriate events
+      bool live = self->_internalMediaStreamTrack->state() == webrtc::MediaStreamTrackInterface::kLive;
+      if (self->_live != live)
+      {
+        if (!live)
+          evt.type = MediaStreamTrack::ENDED;
+        else
+          evt.type = MediaStreamTrack::STARTED;
+        self->_live = live;
+      }
+    }
+    if(MediaStreamTrack::MUTE & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(String::New("onmute")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(mst, 0, argv);
+      }
+    } else if(MediaStreamTrack::UNMUTE & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(String::New("onunmute")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(mst, 0, argv);
+      }
+    }
+    if(MediaStreamTrack::STARTED & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(String::New("onstarted")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(mst, 0, argv);
+      }
+    }
+    if(MediaStreamTrack::ENDED & evt.type) 
+    {
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(String::New("onended")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[0];
+        callback->Call(mst, 0, argv);
+      }
+    }
+    
+  }
+  scope.Close(Undefined());
+  TRACE_END;
+}
+
+void MediaStreamTrack::OnChanged()
+{
+  TRACE_CALL;
+  QueueEvent(MediaStreamTrack::CHANGE, static_cast<void*>(NULL));
+  TRACE_END;
+}
+
+webrtc::MediaStreamTrackInterface* MediaStreamTrack::GetInterface() {
+    return _internalMediaStreamTrack;
+}
+
+NAN_METHOD(MediaStreamTrack::clone) {
+  TRACE_CALL;
+  NanScope();
+  // todo: implement
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_METHOD(MediaStreamTrack::stop) {
+  TRACE_CALL;
+  NanScope();
+  // todo: implement
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_GETTER(MediaStreamTrack::GetId) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+  std::string id = self->_internalMediaStreamTrack->id();
+
+  TRACE_END;
+  NanReturnValue(String::New(id.c_str()));
+}
+
+NAN_GETTER(MediaStreamTrack::GetLabel) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+  std::string label = self->_internalMediaStreamTrack->id();
+
+  TRACE_END;
+  NanReturnValue(String::New(label.c_str()));
+}
+
+NAN_GETTER(MediaStreamTrack::GetKind) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+  std::string kind = self->_internalMediaStreamTrack->kind();
+
+  TRACE_END;
+  NanReturnValue(String::New(kind.c_str()));
+}
+
+NAN_GETTER(MediaStreamTrack::GetEnabled) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+  bool enabled = self->_internalMediaStreamTrack->enabled();
+
+  TRACE_END;
+  NanReturnValue(Boolean::New(enabled));
+}
+
+NAN_GETTER(MediaStreamTrack::GetMuted) {
+  TRACE_CALL;
+  NanScope();
+  TRACE_END;
+  NanReturnValue(Boolean::New(false));
+}
+
+NAN_GETTER(MediaStreamTrack::GetReadOnly) {
+  TRACE_CALL;
+  NanScope();
+  TRACE_END;
+  NanReturnValue(Boolean::New(false));
+}
+
+NAN_GETTER(MediaStreamTrack::GetRemote) {
+  TRACE_CALL;
+  NanScope();
+  TRACE_END;
+  NanReturnValue(Boolean::New(false));
+}
+
+NAN_GETTER(MediaStreamTrack::GetReadyState) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+
+  webrtc::MediaStreamTrackInterface::TrackState state = self->_internalMediaStreamTrack->state();
+
+  TRACE_END;
+  NanReturnValue(Number::New(static_cast<uint32_t>(state)));
+}
+
+NAN_SETTER(MediaStreamTrack::SetEnabled) {
+  TRACE_CALL;
+  NanScope();
+
+  MediaStreamTrack* self = ObjectWrap::Unwrap<MediaStreamTrack>( args.Holder() );
+  self->_internalMediaStreamTrack->set_enabled(value->ToBoolean()->Value());
+  
+  TRACE_END;
+}
+
+NAN_SETTER(MediaStreamTrack::ReadOnly) {
+  INFO("MediaStreamTrack::ReadOnly");
+}
+
+void MediaStreamTrack::Init( Handle<Object> exports ) {
+  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
+  tpl->SetClassName( String::NewSymbol( "MediaStreamTrack" ) );
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "clone" ),
+    FunctionTemplate::New( clone )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "stop" ),
+    FunctionTemplate::New( stop )->GetFunction() );
+
+  tpl->InstanceTemplate()->SetAccessor(String::New("id"), GetId, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("kind"), GetKind, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("label"), GetLabel, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("enabled"), GetEnabled, SetEnabled);
+  tpl->InstanceTemplate()->SetAccessor(String::New("muted"), GetMuted, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("_readonly"), GetReadOnly, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("remote"), GetRemote, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(String::New("readyState"), GetReadyState, ReadOnly);
+
+  NanAssignPersistent(Function, constructor, tpl->GetFunction());
+  exports->Set( String::NewSymbol("MediaStreamTrack"), tpl->GetFunction() );
+}

--- a/src/mediastreamtrack.h
+++ b/src/mediastreamtrack.h
@@ -1,0 +1,91 @@
+#ifndef __MEDIASTREAMTRACK_H__
+#define __MEDIASTREAMTRACK_H__
+
+#include <string>
+
+#include <node.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <uv.h>
+
+#include "talk/app/webrtc/jsep.h"
+#include "talk/app/webrtc/mediastreaminterface.h"
+#include "talk/base/thread.h"
+#include "talk/base/scoped_ptr.h"
+#include "webrtc/system_wrappers/interface/ref_count.h"
+
+#include "common.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+class MediaStreamTrack
+: public ObjectWrap,
+  public webrtc::ObserverInterface
+{
+    
+public:
+
+  enum AsyncEventType {
+    MUTE = 0x1 << 0, // 1
+    UNMUTE = 0x1 << 1, // 2
+    STARTED = 0x1 << 2, // 4
+    ENDED = 0x1 << 3, // 8
+    CHANGE = 0x1 << 4, // 16
+  };
+  
+  MediaStreamTrack(webrtc::MediaStreamTrackInterface* MediaStreamTrack);
+  ~MediaStreamTrack();
+  
+  //
+  // ObserverInterface implementation.
+  //
+  
+  void OnChanged();
+  
+  //
+  // Nodejs wrapping.
+  //
+  
+  static void Init( Handle<Object> exports );
+  static Persistent<Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_METHOD(stop);
+  static NAN_METHOD(clone);
+  
+  static NAN_GETTER(GetId);
+  static NAN_GETTER(GetKind);
+  static NAN_GETTER(GetLabel);
+  static NAN_GETTER(GetEnabled);
+  static NAN_GETTER(GetMuted);
+  static NAN_GETTER(GetReadOnly);
+  static NAN_GETTER(GetRemote);
+  static NAN_GETTER(GetReadyState);
+  
+  static NAN_SETTER(SetEnabled);
+  static NAN_SETTER(ReadOnly);
+
+  void QueueEvent(MediaStreamTrack::AsyncEventType type, void* data);
+  webrtc::MediaStreamTrackInterface* GetInterface();
+  
+private:
+  static void Run(uv_async_t* handle, int status);
+
+  struct AsyncEvent {
+    AsyncEventType type;
+    void* data;
+  };
+
+  uv_mutex_t lock;
+  uv_async_t async;
+  std::queue<AsyncEvent> _events;
+  
+  bool _live;
+  bool _muted;
+  
+  talk_base::scoped_refptr<webrtc::MediaStreamTrackInterface> _internalMediaStreamTrack;
+};
+
+#endif

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -505,6 +505,37 @@ NAN_METHOD(PeerConnection::AddStream) {
   NanReturnValue(Undefined());
 }
 
+NAN_METHOD(PeerConnection::RemoveStream) {
+  TRACE_CALL;
+  NanScope();
+
+  PeerConnection* self = ObjectWrap::Unwrap<PeerConnection>( args.This() );
+  MediaStream* ms = ObjectWrap::Unwrap<MediaStream>( args[0]->ToObject() );
+  
+  self->_internalPeerConnection->RemoveStream(ms->GetInterface());
+
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_METHOD(PeerConnection::GetLocalStreams) {
+  TRACE_CALL;
+  NanScope();
+
+  PeerConnection* self = ObjectWrap::Unwrap<PeerConnection>( args.This() );
+  talk_base::scoped_refptr<webrtc::StreamCollectionInterface> _streams = self->_internalPeerConnection->local_streams();
+  
+  v8::Local<v8::Array> array = v8::Array::New(_streams->count());
+  for (unsigned int index = 0; index < _streams->count(); index++) {
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = v8::External::New(static_cast<void*>(_streams->at(index)));
+    array->Set(index, NanPersistentToLocal(MediaStream::constructor)->NewInstance(1, cargv));
+  }
+  
+  TRACE_END;
+  NanReturnValue(array);
+}
+
 NAN_METHOD(PeerConnection::GetRemoteStreams) {
   TRACE_CALL;
   NanScope();

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -15,6 +15,7 @@
 #include "common.h"
 #include "peerconnection.h"
 #include "datachannel.h"
+#include "mediastream.h"
 
 using namespace node;
 using namespace v8;
@@ -236,6 +237,34 @@ void PeerConnection::Run(uv_async_t* handle, int status)
         argv[0] = dc;
         callback->Call(pc, 1, argv);
       }
+    } else if(PeerConnection::NOTIFY_ADD_STREAM & evt.type)
+    {
+      webrtc::MediaStreamInterface* msi = static_cast<webrtc::MediaStreamInterface*>(evt.data);
+      v8::Local<v8::Value> cargv[1];
+      cargv[0] = v8::External::New(static_cast<void*>(msi));
+      v8::Local<v8::Value> ms = NanPersistentToLocal(MediaStream::constructor)->NewInstance(1, cargv);
+
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(pc->Get(String::New("onaddstream")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[1];
+        argv[0] = ms;
+        callback->Call(pc, 1, argv);
+      }
+    } else if(PeerConnection::NOTIFY_REMOVE_STREAM & evt.type)
+    {
+      webrtc::MediaStreamInterface* msi = static_cast<webrtc::MediaStreamInterface*>(evt.data);
+      v8::Local<v8::Value> cargv[1];
+      cargv[0] = v8::External::New(static_cast<void*>(msi));
+      v8::Local<v8::Value> ms = NanPersistentToLocal(MediaStream::constructor)->NewInstance(1, cargv);
+
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(pc->Get(String::New("onremovestream")));
+      if(!callback.IsEmpty())
+      {
+        v8::Local<v8::Value> argv[1];
+        argv[0] = ms;
+        callback->Call(pc, 1, argv);
+      }
     }
     // FIXME: delete event
   }
@@ -269,13 +298,17 @@ void PeerConnection::OnIceGatheringChange( webrtc::PeerConnectionInterface::IceG
   TRACE_END;
 }
 
-void PeerConnection::OnAddStream( webrtc::MediaStreamInterface* stream ) {
+void PeerConnection::OnAddStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
+  media_stream->AddRef();
+  QueueEvent(PeerConnection::NOTIFY_ADD_STREAM, static_cast<void*>(media_stream));
   TRACE_END;
 }
 
-void PeerConnection::OnRemoveStream( webrtc::MediaStreamInterface* stream ) {
+void PeerConnection::OnRemoveStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
+  media_stream->AddRef();
+  QueueEvent(PeerConnection::NOTIFY_REMOVE_STREAM, static_cast<void*>(media_stream));
   TRACE_END;
 }
 
@@ -458,6 +491,63 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   NanReturnValue(dc);
 }
 
+NAN_METHOD(PeerConnection::AddStream) {
+  TRACE_CALL;
+  NanScope();
+
+  PeerConnection* self = ObjectWrap::Unwrap<PeerConnection>( args.This() );
+  MediaStream* ms = ObjectWrap::Unwrap<MediaStream>( args[0]->ToObject() );
+  Handle<Object> constraintsDict = Handle<Object>::Cast(args[1]);
+  
+  self->_internalPeerConnection->AddStream(ms->GetInterface(),NULL);
+
+  TRACE_END;
+  NanReturnValue(Undefined());
+}
+
+NAN_METHOD(PeerConnection::GetRemoteStreams) {
+  TRACE_CALL;
+  NanScope();
+
+  PeerConnection* self = ObjectWrap::Unwrap<PeerConnection>( args.This() );
+  talk_base::scoped_refptr<webrtc::StreamCollectionInterface> _streams = self->_internalPeerConnection->remote_streams();
+  
+  v8::Local<v8::Array> array = v8::Array::New(_streams->count());
+  for (unsigned int index = 0; index < _streams->count(); index++) {
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = v8::External::New(static_cast<void*>(_streams->at(index)));
+    array->Set(index, NanPersistentToLocal(MediaStream::constructor)->NewInstance(1, cargv));
+  }
+  
+  TRACE_END;
+  NanReturnValue(array);
+}
+
+NAN_METHOD(PeerConnection::GetStreamById) {
+  TRACE_CALL;
+  NanScope();
+
+  PeerConnection* self = ObjectWrap::Unwrap<PeerConnection>( args.This() );
+  v8::String::Utf8Value param1(args[0]->ToString());
+  std::string _id = std::string(*param1);
+  talk_base::scoped_refptr<webrtc::StreamCollectionInterface> _local = self->_internalPeerConnection->local_streams();
+  talk_base::scoped_refptr<webrtc::StreamCollectionInterface> _remote = self->_internalPeerConnection->remote_streams();
+  webrtc::MediaStreamInterface* stream = _local->find(_id);
+  if (!stream) {
+      stream = _remote->find(_id);
+  }
+  
+  TRACE_END;
+  if (stream) {
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = v8::External::New(static_cast<void*>(stream));
+    v8::Local<v8::Value> ms = NanPersistentToLocal(MediaStream::constructor)->NewInstance(1, cargv);
+    NanReturnValue(ms);
+  } else {
+    NanReturnValue(Undefined());
+  }
+}
+
 NAN_METHOD(PeerConnection::UpdateIce) {
   TRACE_CALL;
   NanScope();
@@ -578,20 +668,20 @@ void PeerConnection::Init( Handle<Object> exports ) {
   tpl->PrototypeTemplate()->Set( String::NewSymbol( "createDataChannel" ),
     FunctionTemplate::New( CreateDataChannel )->GetFunction() );
 
-  // tpl->PrototypeTemplate()->Set( String::NewSymbol( "getLocalStreams" ),
-  //     FunctionTemplate::New( GetLocalStreams )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getLocalStreams" ),
+    FunctionTemplate::New( GetLocalStreams )->GetFunction() );
 
-  // tpl->PrototypeTemplate()->Set( String::NewSymbol( "getRemoteStreams" ),
-  //     FunctionTemplate::New( GetRemtoeStreams )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getRemoteStreams" ),
+    FunctionTemplate::New( GetRemoteStreams )->GetFunction() );
 
-  // tpl->PrototypeTemplate()->Set( String::NewSymbol( "getStreamById" ),
-  //     FunctionTemplate::New( GetStreamById )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getStreamById" ),
+    FunctionTemplate::New( GetStreamById )->GetFunction() );
 
-  // tpl->PrototypeTemplate()->Set( String::NewSymbol( "addStream" ),
-  //     FunctionTemplate::New( AddStream )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "addStream" ),
+    FunctionTemplate::New( AddStream )->GetFunction() );
 
-  // tpl->PrototypeTemplate()->Set( String::NewSymbol( "removeStream" ),
-  //     FunctionTemplate::New( RemoveStream )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( String::NewSymbol( "removeStream" ),
+    FunctionTemplate::New( RemoveStream )->GetFunction() );
 
   tpl->PrototypeTemplate()->Set( String::NewSymbol( "close" ),
     FunctionTemplate::New( Close )->GetFunction() );

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -140,7 +140,9 @@ public:
     ICE_CANDIDATE = 0x1 << 13, // 8092
     SIGNALING_STATE_CHANGE = 0x1 << 14, // 16384
     ICE_CONNECTION_STATE_CHANGE = 0x1 << 15, // 32768
-    ICE_GATHERING_STATE_CHANGE = 0x1 << 16, // 65536
+    ICE_GATHERING_STATE_CHANGE = 0x1 << 16, // 65536    
+    NOTIFY_ADD_STREAM = 0x1 << 17, // 131072
+    NOTIFY_REMOVE_STREAM = 0x1 << 18, // 262144
 
     ERROR_EVENT = CREATE_OFFER_ERROR | CREATE_ANSWER_ERROR |
                   SET_LOCAL_DESCRIPTION_ERROR | SET_REMOTE_DESCRIPTION_ERROR |
@@ -184,6 +186,11 @@ public:
   static NAN_METHOD(UpdateIce);
   static NAN_METHOD(AddIceCandidate);
   static NAN_METHOD(CreateDataChannel);
+  static NAN_METHOD(GetLocalStreams);
+  static NAN_METHOD(GetRemoteStreams);
+  static NAN_METHOD(GetStreamById);
+  static NAN_METHOD(AddStream);
+  static NAN_METHOD(RemoveStream);
   static NAN_METHOD(Close);
 
   static NAN_GETTER(GetLocalDescription);


### PR DESCRIPTION
Implemented RTCMediaStream and RTCMediaStreamTrack. For the moment, we don't have an implementation to create a stream, but we should be able to retrieve the objects from RTCPeerConnection once it receives a remote stream. This object can then be added to other RTCPeerConnections.
