### PR TITLE
Updates to ice connection state names

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -113,12 +113,11 @@ PeerConnection.prototype.RTCSignalingStates = [
 
 PeerConnection.prototype.RTCIceConnectionStates = [
   'new',
-  'gathering',
-  'waiting',
   'checking',
   'connected',
+  'completed',
   'failed',
-  // 'disconnected',
+  'disconnected',
   'closed'
 ];
 


### PR DESCRIPTION
Update connection states to match current spec and what is likely implemented in underlying webrtc libjingle code.

Doing the next round of test updates and everything looks good.  I noticed, while doing the tests that the peers managed to connect to one another but were still reporting an `iceConnectionState` of `waiting`, which makes sense as that array index now maps to `connected` :)

Things are looking good!
