### PR TITLE
Expose oniceconnectionstatechange on RTCPeerConnection

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -97,6 +97,7 @@ function PeerConnection(configuration, constraints) {
   this.onicecandidate = null;
   this.onsignalingstatechange = null;
   this.onicegatheringstatechange = null;
+  this.oniceconnectionstatechange = null;
   this.ondatachannel = null;
   this.onaddstream = null;
   this.onremovestream = null;
@@ -229,6 +230,14 @@ PeerConnection.prototype.getOnSignalingStateChange = function() {
 PeerConnection.prototype.setOnSignalingStateChange = function(cb) {
   // FIXME: throw an exception if cb isn't callable
   this.onsignalingstatechange = cb;
+};
+
+PeerConnection.prototype.getIceConnectionStateChange = function() {
+  return this.oniceconnectionstatechange;
+};
+
+PeerConnection.prototype.setOnIceConnectionStateChange = function(cb) {
+  this.oniceconnectionstatechange = cb;
 };
 
 PeerConnection.prototype.getOnIceCandidate = function() {
@@ -401,6 +410,14 @@ function RTCPeerConnection(configuration, constraints) {
       },
       set: function(cb) {
         pc.setOnSignalingStateChange(cb);
+      }
+    },
+    'oniceconnectionstatechange': {
+      get: function() {
+        return pc.getIceConnectionStateChange();
+      },
+      set: function(cb) {
+        pc.setOnIceConnectionStateChange(cb);
       }
     },
     'onicecandidate': {


### PR DESCRIPTION
Expose the `oniceconnectionstatechange` event endpoint as per the implementation of `onsignalingstatechange'
