### PR TITLE
Alternative build implementation progress

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,182 +1,37 @@
 #!/usr/bin/sh
 
+var async = require('async');
 var path = require('path');
 var os = require('os');
 var fs = require('fs');
 var sys = require('sys');
+var mkdirp = require('mkdirp');
 var exec = require('child_process').exec;
 var spawn = require('child_process').spawn;
+var gclient = require('depot_tools/gclient');
+var ninja = require('depot_tools/ninja');
+var PROJECT_DIR = path.resolve(__dirname, '..');
+var LIB_WEBRTC_DIR = path.join(PROJECT_DIR, 'third_party', 'libwebrtc');
 
+var tasks = [
+  ['config', 'http://webrtc.googlecode.com/svn/trunk'],
+  ['sync'],
+  ['runhooks']
+].map(gclient(LIB_WEBRTC_DIR)).concat([
+  ninja(LIB_WEBRTC_DIR, ['-C', 'trunk/out/Release']),
+  nodegyp_build
+]);
 
-var PROJECT_DIR = process.cwd();
-
-var LIB_DIR = PROJECT_DIR + '/third_party';
-var LIB_WEBRTC_DIR = LIB_DIR + '/libwebrtc';
-
-var TOOLS_DIR = PROJECT_DIR + '/tools';
-var TOOLS_DEPOT_TOOLS_DIR = TOOLS_DIR + '/depot_tools';
-
-
-var GCLIENT = TOOLS_DEPOT_TOOLS_DIR+"/gclient";
-
+mkdirp(LIB_WEBRTC_DIR, function(err) {
+  async.series(tasks, function(err) {
+    console.log(err ? 'Build errored: ' + err : 'Build complete');
+  });
+});
 
 function read_stream(stream)
 {
   stream.read();
   process.stdout.write('.');
-}
-
-
-process.env['GYP_GENERATORS'] = 'ninja';
-
-
-function depot_tools(callback)
-{
-  console.info("depot_tools");
-  process.stdout.write('.');
-
-  // Directory for tools
-  if(!fs.existsSync(TOOLS_DIR))
-  {
-    fs.mkdirSync(TOOLS_DIR);
-  }
-  process.chdir(TOOLS_DIR);
-
-  // Download depot tools
-  if(!fs.existsSync(TOOLS_DEPOT_TOOLS_DIR))
-  {
-    var child = exec("git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git");
-    child.on('exit', function(code, signal)
-    {
-      process.stdout.write('\n');
-      if(0 === code && !signal)
-      {
-        console.log('depot_tools complete');
-        gclient_config(callback);
-      }
-      else
-      {
-        console.error('depot_tools failed:', code, signal);
-      }
-    });
-  }
-  else
-  {
-    console.log('depot_tools not required');
-    gclient_config(callback);
-  }
-}
-
-function gclient_config(callback)
-{
-  console.info("gclient_config");
-  process.stdout.write('.');
-
-  // Directory for libwebrtc
-  if(!fs.existsSync(LIB_WEBRTC_DIR))
-  {
-    if(!fs.existsSync(LIB_DIR))
-    {
-      fs.mkdirSync(LIB_DIR);
-    }
-
-    fs.mkdirSync(LIB_WEBRTC_DIR);
-  }
-  process.chdir(LIB_WEBRTC_DIR);
-
-  // Download libwebrtc
-  var child = exec(GCLIENT+" config http://webrtc.googlecode.com/svn/trunk");
-  child.on('exit', function(code, signal)
-  {
-    process.stdout.write('\n');
-    if(0 === code && !signal)
-    {
-      console.log('gclient_config complete');
-      gclient_sync(callback);
-    }
-    else
-    {
-      console.error('gclient_config failed:', code, signal);
-    }
-  });
-}
-
-function gclient_sync(callback)
-{
-  console.info("gclient_sync");
-  process.stdout.write('.');
-
-  process.chdir(LIB_WEBRTC_DIR);
-
-  var child = spawn(GCLIENT, ["sync"]);
-  child.stdout.on('readable', read_stream.bind(undefined, child.stdout));
-  child.on('exit', function(code, signal)
-  {
-    process.stdout.write('\n');
-    if(0 === code && !signal)
-    {
-      console.log('gclient_sync complete');
-      gclient_runhooks(callback);
-    }
-    else
-    {
-      console.error('gclient_sync failed:', code, signal);
-    }
-  });
-}
-
-function gclient_runhooks(callback)
-{
-  console.info("gclient_runhooks");
-  process.stdout.write('.');
-
-  process.chdir(LIB_WEBRTC_DIR);
-
-  var child = spawn(GCLIENT, ["runhooks"]);
-  child.stdout.on('readable', read_stream.bind(undefined, child.stdout));
-  child.on('exit', function(code, signal)
-  {
-    process.stdout.write('\n');
-    if(0 === code && !signal)
-    {
-      console.log('gclient_runhooks complete');
-      ninja_build(callback);
-    }
-    else
-    {
-      console.error('gclient_runhooks failed:', code, signal);
-    }
-  });
-}
-
-function ninja_build(callback)
-{
-  console.info("ninja_build");
-  process.stdout.write('.');
-
-  process.chdir(LIB_WEBRTC_DIR);
-
-  var args = ["-C", "trunk/out/Release"];
-  if('linux' == os.platform())
-  {
-    args.push("peerconnection_client");
-  }
-
-  var child = spawn("ninja", args);
-  child.stdout.on('readable', read_stream.bind(undefined, child.stdout));
-  child.on('exit', function(code, signal)
-  {
-    process.stdout.write('\n');
-    if(0 === code && !signal)
-    {
-      console.log('ninja_build complete');
-      nodegyp_build(callback);
-    }
-    else
-    {
-      console.error('ninja_build failed:', code, signal);
-    }
-  });
 }
 
 function nodegyp_build(callback)
@@ -203,7 +58,7 @@ function nodegyp_build(callback)
   });
 }
 
-depot_tools(function()
-{
-  console.log('wrtc build complete');
-});
+// depot_tools(function()
+// {
+//   console.log('wrtc build complete');
+// });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "wrtc",
   "description": "Standards-compliant WebRTC implementation for Node",
-  "keywords": ["webrtc", "p2p", "peer"],
+  "keywords": [
+    "webrtc",
+    "p2p",
+    "peer"
+  ],
   "version": "0.0.9",
   "author": "Alan K <ack@modeswitch.org> (http://blog.modeswitch.org)",
   "homepage": "http://js-platform.github.io/node-webrtc/",
@@ -19,7 +23,10 @@
   "dependencies": {
     "bindings": "~1.1.1",
     "node-gyp": "~0.10.10",
-    "nan": "~0.4.4"
+    "nan": "~0.4.4",
+    "mkdirp": "~0.3.5",
+    "async": "~0.2.10",
+    "depot_tools": "0.0.4"
   },
   "devDependencies": {
     "ws": "~0.4.31",


### PR DESCRIPTION
This is intended as more of a discussion than a straight up pull-request. I know the build process has been discussed in issues so I had a bit of a play around with how I thought I might have tackled the build process, and in particular considering what it might look like as we work towards windows support (#42).  I'm actually giving it a test run on a windows box at the moment, and it's ticking along nicely (so far).

I have taken quite a different approach to what has been done in previous build scripts (this one is not hiding any output from the depot_tools, i.e. gclient).  Additionally I created a simple [node modules](https://github.com/DamonOehlman/node-depot_tools) that is responsible for downloading depot_tools in what I think is a fairly cross platform way (tested on windows).

The actual build script is a bit tighter too, but it might be considered a little bit terse by some (which I understand).  End result of the build script (without touching the node-gyp process) looks something like:

``` js
var async = require('async');
var path = require('path');
var os = require('os');
var fs = require('fs');
var sys = require('sys');
var mkdirp = require('mkdirp');
var exec = require('child_process').exec;
var spawn = require('child_process').spawn;
var gclient = require('depot_tools/gclient');
var ninja = require('depot_tools/ninja');
var PROJECT_DIR = path.resolve(__dirname, '..');
var LIB_WEBRTC_DIR = path.join(PROJECT_DIR, 'third_party', 'libwebrtc');

var tasks = [
  ['config', 'http://webrtc.googlecode.com/svn/trunk'],
  ['sync'],
  ['runhooks']
].map(gclient(LIB_WEBRTC_DIR)).concat([
  ninja(LIB_WEBRTC_DIR, ['-C', 'trunk/out/Release']),
  nodegyp_build
]);

mkdirp(LIB_WEBRTC_DIR, function(err) {
  async.series(tasks, function(err) {
    console.log(err ? 'Build errored: ' + err : 'Build complete');
  });
});

function read_stream(stream)
{
  stream.read();
  process.stdout.write('.');
}

function nodegyp_build(callback)
{
  console.info("nodegyp_build");
  process.stdout.write('.');

  process.chdir(PROJECT_DIR);

  var child = spawn("node-gyp", ["rebuild"]);
  child.stdout.on('readable', read_stream.bind(undefined, child.stdout));
  child.on('exit', function(code, signal)
  {
    process.stdout.write('\n');
    if(0 === code && !signal)
    {
      console.log('nodegyp_build complete');
      callback();
    }
    else
    {
      console.error('nodegyp_build failed:', code, signal);
    }
  });
}
```
