### PR TITLE
Implement RTCDataChannelEvent

### DIFF
--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -76,7 +76,9 @@ wss.on('connection', function(ws)
   function doHandleDataChannels()
   {
     var labels = Object.keys(dataChannelSettings);
-    pc.ondatachannel = function(channel) {
+    pc.ondatachannel = function(evt) {
+      var channel = evt.channel;
+
       console.log('ondatachannel', channel.label, channel.readyState);
       var label = channel.label;
       pendingDataChannels[label] = channel;

--- a/lib/datachannelevent.js
+++ b/lib/datachannelevent.js
@@ -1,0 +1,5 @@
+function RTCDataChannelEvent(channel) {
+  this.channel = channel;
+}
+
+module.exports = RTCDataChannelEvent;

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -6,7 +6,7 @@ var RTCError = require('./error');
 var RTCDataChannel = require('./datachannel');
 var RTCMediaStream = require('./mediastream');
 var RTCIceCandidateEvent = require('./icecandidateevent');
-
+var RTCDataChannelEvent = require('./datachannelevent');
 
 function PeerConnection(configuration, constraints) {
   var that = this;
@@ -76,7 +76,7 @@ function PeerConnection(configuration, constraints) {
     if(that.ondatachannel && typeof that.ondatachannel == 'function') {
       that._dataChannels[internalDC.label] = internalDC;
       var dc = new RTCDataChannel(internalDC);
-      that.ondatachannel.apply(that, [dc]);
+      that.ondatachannel.apply(that, [new RTCDataChannelEvent(dc)]);
     }
   };
 


### PR DESCRIPTION
Like the `RTCIceCandidateEvent` but used for when a new data channel has been discovered by a peer (`ondatachannel`).  This is basically this signature of the event handler in the browser, so if you use this signature webrtc libraries will be compatible.
