### PR TITLE
Should have been implemented as a data member not message

### DIFF
--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -92,7 +92,7 @@ wss.on('connection', function(ws)
         }
       };
       channel.onmessage = function(evt) {
-        console.log('onmessage', evt.message);
+        console.log('onmessage', evt.data);
         var response = new  Uint8Array([107, 99, 97, 0]);
         channel.send(response.buffer);
       };

--- a/lib/datachannelmessageevent.js
+++ b/lib/datachannelmessageevent.js
@@ -1,5 +1,5 @@
 function RTCDataChannelMessageEvent(message) {
-  this.message = message;
+  this.data = message;
 }
 
 module.exports = RTCDataChannelMessageEvent;


### PR DESCRIPTION
Hey Alan,

I messed up here (must have been tired). The message payload is actually meant to be contained within the data property of the event.

I'm currently expanding the tape tests to check that we have dc connectivity and comms and picked it up there...

Sorry for the hassle.

Cheers,
Damon.
