### PR TITLE
Package.json main pointing to Javascript files instead of bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "http://github.com/js-platform/node-webrtc.git"
   },
-  "main": "./build/Release/webrtc.node",
+  "main": "lib/index.js",
   "browser": "lib/browser.js",
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
This fix issue #77. It also has the fixes done by @wouldgo regarding download of libWebrtc (they should be merged before...).
