### PR TITLE
Merged internal and public PeerConnection classes

### DIFF
--- a/lib/datachannel.js
+++ b/lib/datachannel.js
@@ -53,35 +53,29 @@ var RTCDataChannelMessageEvent = require('./datachannelmessageevent');
 function RTCDataChannel(internalDC) {
   var that = this;
 
-  internalDC.onerror = function onerror() {
+  EventTarget.call(this);
 
+  internalDC.onerror = function onerror() {
+    that.dispatchEvent(new Event('error'));
   };
 
   internalDC.onmessage = function onmessage(data) {
-    if(that.onmessage && typeof that.onmessage == 'function') {
-       that.onmessage(new RTCDataChannelMessageEvent(data));
-    }
+    that.dispatchEvent(new RTCDataChannelMessageEvent(data));
   };
 
   internalDC.onstatechange = function onstatechange() {
     var state = that.readyState;
 
-    if('open' == state) {
-      if(that.onopen && typeof that.onopen == 'function') {
-         that.onopen();
-      }
-    } else if('closed' == state) {
-      if(that.onclose && typeof that.onclose == 'function') {
-         that.onclose();
-      }
+    switch(state) {
+      case 'open':
+        that.dispatchEvent(new Event('open'));
+      break;
+
+      case 'closed':
+        that.dispatchEvent(new Event('close'));
+      break;
     }
   };
-
-
-  var onerror   = null;
-  var onmessage = null;
-  var onopen    = null;
-  var onclose   = null;
 
 
   Object.defineProperties(this, {
@@ -106,43 +100,6 @@ function RTCDataChannel(internalDC) {
         if(typenum >= 0) {
           internalDC.binaryType = typenum;
         }
-      }
-    },
-
-    'onerror': {
-      get: function() {
-        return onerror;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onerror = cb;
-      }
-    },
-    'onopen': {
-      get: function() {
-        return onopen;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onopen = cb;
-      }
-    },
-    'onmessage': {
-      get: function() {
-        return onmessage;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onmessage = cb;
-      }
-    },
-    'onclose': {
-      get: function() {
-        return onclose;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onclose = cb;
       }
     }
   });

--- a/lib/datachannel.js
+++ b/lib/datachannel.js
@@ -1,225 +1,174 @@
+var EventTarget = require('eventtarget');
+
 var RTCDataChannelMessageEvent = require('./datachannelmessageevent');
 
-function DataChannel(internalDC) {
+
+//function DataChannel(internalDC) {
+//  this._queue = [];
+//  this._pending = null;
+//};
+
+//DataChannel.prototype._getDC = function _getDC() {
+//  if(!this._dc) {
+//    throw new Error('RTCDataChannel is gone');
+//  }
+//  return this._dc;
+//};
+
+//DataChannel.prototype._queueOrRun = function _queueOrRun(obj) {
+//  var pc = this._getPC();
+//  // this._checkClosed();
+//  if(null == this._pending) {
+//    pc[obj.func].apply(pc, obj.args);
+//    if(obj.wait) {
+//      this._pending = obj;
+//    }
+//  } else {
+//    this._queue.push(obj);
+//  }
+//};
+
+//DataChannel.prototype._executeNext = function _executeNext() {
+//  var obj, pc;
+//  pc = this._getPC();
+//  if(this._queue.length > 0) {
+//    obj = this._queue.shift();
+//    pc[obj.func].apply(pc, obj.args);
+//    if(obj.wait)
+//    {
+//      this._pending = obj;
+//    } else {
+//      this._executeNext();
+//    }
+//  } else {
+//    this._pending = null;
+//  }
+//};
+
+//DataChannel.prototype._shutdown = function _shutdown() {
+//  this._getDC().shutdown();
+//};
+
+
+function RTCDataChannel(internalDC) {
   var that = this;
-  this._dc = internalDC;
 
-  this._queue = [];
-  this._pending = null;
-
-  this._dc.onerror = function onerror() {
+  internalDC.onerror = function onerror() {
 
   };
 
-  this._dc.onmessage = function onmessage(data) {
+  internalDC.onmessage = function onmessage(data) {
     if(that.onmessage && typeof that.onmessage == 'function') {
-      that.onmessage.apply(that, [ new RTCDataChannelMessageEvent(data) ]);
+       that.onmessage(new RTCDataChannelMessageEvent(data));
     }
   };
 
-  this._dc.onstatechange = function onstatechange() {
-    var state = that.getReadyState();
+  internalDC.onstatechange = function onstatechange() {
+    var state = that.readyState;
+
     if('open' == state) {
       if(that.onopen && typeof that.onopen == 'function') {
-        that.onopen.apply(that, []);
+         that.onopen();
       }
     } else if('closed' == state) {
       if(that.onclose && typeof that.onclose == 'function') {
-        that.onclose.apply(that, []);
+         that.onclose();
       }
     }
   };
 
-  this.onerror = null;
-  this.onmessage = null;
-  this.onopen = null;
-  this.onclose = null;
-};
 
-module.exports = DataChannel;
+  var onerror   = null;
+  var onmessage = null;
+  var onopen    = null;
+  var onclose   = null;
 
-DataChannel.prototype._getDC = function _getDC() {
-  if(!this._dc) {
-    throw new Error('RTCDataChannel is gone');
-  }
-  return this._dc;
-};
 
-DataChannel.prototype._queueOrRun = function _queueOrRun(obj) {
-  var pc = this._getPC();
-  // this._checkClosed();
-  if(null == this._pending) {
-    pc[obj.func].apply(pc, obj.args);
-    if(obj.wait) {
-      this._pending = obj;
+  Object.defineProperties(this, {
+    'label': {
+      get: function getLabel() {
+        return internalDC.label;
+      }
+    },
+    'readyState': {
+      get: function getReadyState() {
+        var state = internalDC.readyState;
+        return this.RTCDataStates[state];
+      }
+    },
+    'binaryType': {
+      get: function getBinaryType() {
+        var type = internalDC.binaryType;
+        return this.BinaryTypes[type];
+      },
+      set: function(type) {
+        var typenum = this.BinaryTypes.indexOf(type);
+        if(typenum >= 0) {
+          internalDC.binaryType = typenum;
+        }
+      }
+    },
+
+    'onerror': {
+      get: function() {
+        return onerror;
+      },
+      set: function(cb) {
+        // FIXME: throw an exception if cb isn't callable
+        onerror = cb;
+      }
+    },
+    'onopen': {
+      get: function() {
+        return onopen;
+      },
+      set: function(cb) {
+        // FIXME: throw an exception if cb isn't callable
+        onopen = cb;
+      }
+    },
+    'onmessage': {
+      get: function() {
+        return onmessage;
+      },
+      set: function(cb) {
+        // FIXME: throw an exception if cb isn't callable
+        onmessage = cb;
+      }
+    },
+    'onclose': {
+      get: function() {
+        return onclose;
+      },
+      set: function(cb) {
+        // FIXME: throw an exception if cb isn't callable
+        onclose = cb;
+      }
     }
-  } else {
-    this._queue.push(obj);
-  }
+  });
+
+  this.send = function send(data) {
+    internalDC.send(data);
+  };
+
+  this.close = function close() {
+    internalDC.close();
+  };
 };
 
-DataChannel.prototype._executeNext = function _executeNext() {
-  var obj, pc;
-  pc = this._getPC();
-  if(this._queue.length > 0) {
-    obj = this._queue.shift();
-    pc[obj.func].apply(pc, obj.args);
-    if(obj.wait)
-    {
-      this._pending = obj;
-    } else {
-      this._executeNext();
-    }
-  } else {
-    this._pending = null;
-  }
-};
-
-DataChannel.prototype.RTCDataStates = [
+RTCDataChannel.prototype.RTCDataStates =
+[
   'connecting',
   'open',
   'closing',
   'closed'
 ];
 
-DataChannel.prototype.BinaryTypes = [
-  'blob', // Note: not sure what to do about this, since node doesn't have a Blob API
+RTCDataChannel.prototype.BinaryTypes =
+[
+  'blob',  // Note: not sure what to do about this, since node doesn't have a Blob API
   'arraybuffer'
 ];
 
-DataChannel.prototype.send = function send(data) {
-  this._getDC().send(data);
-};
-
-DataChannel.prototype.close = function close() {
-  this._getDC().close();
-};
-
-DataChannel.prototype._shutdown = function _shutdown() {
-  this._getDC().shutdown();
-};
-
-DataChannel.prototype.getLabel = function getLabel() {
-  return this._getDC().label;
-};
-
-DataChannel.prototype.getReadyState = function getReadyState() {
-  var state = this._getDC().readyState;
-  return this.RTCDataStates[state];
-};
-
-DataChannel.prototype.getBinaryType = function getBinaryType() {
-  var type = this._getDC().binaryType;
-  return this.BinaryTypes[type];
-};
-
-DataChannel.prototype.setBinaryType = function setBinaryType(type) {
-  var typenum = this.BinaryTypes.indexOf(type);
-  if(typenum >= 0) {
-    this._getDC().binaryType = typenum;
-  }
-};
-
-DataChannel.prototype.getOnError = function() {
-  return this.onerror;
-};
-
-DataChannel.prototype.setOnError = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onerror = cb;
-};
-
-DataChannel.prototype.getOnOpen = function() {
-  return this.onopen;
-};
-
-DataChannel.prototype.setOnOpen = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onopen = cb;
-};
-
-DataChannel.prototype.getOnMessage = function() {
-  return this.onmessage;
-};
-
-DataChannel.prototype.setOnMessage = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onmessage = cb;
-};
-
-DataChannel.prototype.getOnClose = function() {
-  return this.onclose;
-};
-
-DataChannel.prototype.setOnClose = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onclose = cb;
-};
-
-
-function RTCDataChannel(internalDC) {
-  var dc = new DataChannel(internalDC);
-
-  Object.defineProperties(this, {
-    'label': {
-      get: function getLabel() {
-        return dc.getLabel();
-      }
-    },
-    'readyState': {
-      get: function getReadyState() {
-        return dc.getReadyState();
-      }
-    },
-    'binaryType': {
-      get: function getBinaryType() {
-        return dc.getBinaryType();
-      },
-      set: function(type) {
-        dc.setBinaryType(type);
-      }
-    },
-    'onerror': {
-      get: function() {
-        return dc.getOnError();
-      },
-      set: function(cb) {
-        dc.setOnError(cb);
-      }
-    },
-    'onopen': {
-      get: function() {
-        return dc.getOnOpen();
-      },
-      set: function(cb) {
-        dc.setOnOpen(cb);
-      }
-    },
-    'onmessage': {
-      get: function() {
-        return dc.getOnMessage();
-      },
-      set: function(cb) {
-        dc.setOnMessage(cb);
-      }
-    },
-    'onclose': {
-      get: function() {
-        return dc.getOnClose();
-      },
-      set: function(cb) {
-        dc.setOnClose(cb);
-      }
-    }
-  });
-
-  this.send = function send() {
-    dc.send.apply(dc, arguments);
-  };
-
-  this.close = function close() {
-    dc.close.apply(dc, arguments);
-  };
-};
 
 module.exports = RTCDataChannel;

--- a/lib/datachannelevent.js
+++ b/lib/datachannelevent.js
@@ -1,5 +1,7 @@
 function RTCDataChannelEvent(channel) {
   this.channel = channel;
 }
+RTCDataChannelEvent.prototype.type = 'datachannel';
+
 
 module.exports = RTCDataChannelEvent;

--- a/lib/datachannelmessageevent.js
+++ b/lib/datachannelmessageevent.js
@@ -1,5 +1,7 @@
 function RTCDataChannelMessageEvent(message) {
   this.data = message;
 }
+RTCDataChannelMessageEvent.prototype.type = 'message';
+
 
 module.exports = RTCDataChannelMessageEvent;

--- a/lib/icecandidateevent.js
+++ b/lib/icecandidateevent.js
@@ -1,5 +1,7 @@
 function RTCIceCandidateEvent(candidate) {
   this.candidate = candidate;
 }
+RTCIceCandidateEvent.prototype.type = 'icecandidate';
+
 
 module.exports = RTCIceCandidateEvent;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,3 @@
-//exports.RTCDataChannel      = require('./datachannel');
 exports.RTCIceCandidate       = require('./icecandidate');
-//exports.RTCMediaStream      = require('./mediastream');
-//exports.RTCMediaStreamTrack = require('./mediastreamtrack');
 exports.RTCPeerConnection     = require('./peerconnection');
 exports.RTCSessionDescription = require('./sessiondescription');

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -1,244 +1,132 @@
 var RTCMediaStreamTrack = require('./mediastreamtrack');
 
-function MediaStream(internalMS) {
-  var that = this;
-  this._ms = internalMS;
+var EventTarget = require('eventtarget');
 
-  this._queue = [];
-  this._pending = null;
-    
-  this._ms.onactive = function onactive() {
-    if(that.onactive && typeof that.onactive == 'function') {
-      that.onactive.apply(that, []);
-    }
-  };
-    
-  this._ms.oninactive = function oninactive() {
-    if(that.oninactive && typeof that.oninactive == 'function') {
-      that.oninactive.apply(that, []);
-    }
-  };
-    
-  this._ms.onaddtrack = function onaddtrack(internalMST) {
-    if(that.onaddtrack && typeof that.onaddtrack == 'function') {
-      var mst = new RTCMediaStreamTrack(internalMST);
-      that.onaddtrack.apply(that, [mst]);
-    }
-  };
-    
-  this._ms.onremovetrack = function onremovetrack(internalMST) {
-    if(that.onremovetrack && typeof that.onremovetrack == 'function') {
-      var mst = new RTCMediaStreamTrack(internalMST);
-      that.onremovetrack.apply(that, [mst]);
-    }
-  };
 
-  this.onactive = null;
-  this.oninactive = null;
-  this.onaddtrack = null;
-  this.onremovetrack = null;
-}
+//MediaStream.prototype._getMS = function _getMS() {
+//  if(!this._ms) {
+//    throw new Error('RTCMediaSteam is gone');
+//  }
+//  return this._ms;
+//};
 
-module.exports = MediaStream;
+//MediaStream.prototype._executeNext = function _executeNext() {
+//  var obj, ms;
+//  ms = this._getMS();
+//  if(this._queue.length > 0) {
+//    obj = this._queue.shift();
+//    ms[obj.func].apply(ms, obj.args);
+//    if(obj.wait)
+//    {
+//      this._pending = obj;
+//    } else {
+//      this._executeNext();
+//    }
+//  } else {
+//    this._pending = null;
+//  }
+//};
 
-MediaStream.prototype._getMS = function _getMS() {
-  if(!this._ms) {
-    throw new Error('RTCMediaSteam is gone');
-  }
-  return this._ms;
-};
-
-MediaStream.prototype._queueOrRun = function _queueOrRun(obj) {
-  var ms = this._getMS();
-  if(null == this._pending) {
-    ms[obj.func].apply(ms, obj.args);
-    if(obj.wait) {
-      this._pending = obj;
-    }
-  } else {
-    this._queue.push(obj);
-  }
-};
-
-MediaStream.prototype._executeNext = function _executeNext() {
-  var obj, ms;
-  ms = this._getMS();
-  if(this._queue.length > 0) {
-    obj = this._queue.shift();
-    ms[obj.func].apply(ms, obj.args);
-    if(obj.wait)
-    {
-      this._pending = obj;
-    } else {
-      this._executeNext();
-    }
-  } else {
-    this._pending = null;
-  }
-};
-
-MediaStream.prototype.getId = function getId() {
-  return this._runImmediately({
-    func: 'getId',
-    args: []
-  });
-};
-
-MediaStream.prototype.isInactive = function isInactive() {
-  return this._runImmediately({
-    func: 'isInactive',
-    args: []
-  });
-};
-
-MediaStream.prototype.getaudiotracks = function getaudiotracks() {
-  return this._runImmediately({
-    func: 'getAudioTracks',
-    args: []
-  });
-};
-
-MediaStream.prototype.getvideotracks = function getvideotracks() {
-  return this._runImmediately({
-    func: 'getVideoTracks',
-    args: []
-  });
-};
-
-MediaStream.prototype.gettrackbyid = function gettrackbyid(id) {
-  return this._runImmediately({
-    func: 'getTrackById',
-    args: [id]
-  });
-};
-
-MediaStream.prototype.addtrack = function addtrack(track) {
-  this._queueOrRun({
-    func: 'addTrack',
-    args: [track._getMST()]
-  });
-};
-
-MediaStream.prototype.removetrack = function removetrack(track) {
-  this._queueOrRun({
-    func: 'removeTrack',
-    args: [track._getMST()]
-  });
-};
-
-// FIXME: implement clone
-/*MediaStream.prototype.clone = function clone() {
-  return this._getMS().clone();
-};*/
-
-MediaStream.prototype.getOnActive = function() {
-  return this.onactive;
-};
-
-MediaStream.prototype.setOnActive = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onactive = cb;
-};
-
-MediaStream.prototype.getOnInactive = function() {
-  return this.oninactive;
-};
-
-MediaStream.prototype.setOnInactive = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.oninactive = cb;
-};
-
-MediaStream.prototype.getOnAddTrack = function() {
-  return this.onaddtrack;
-};
-
-MediaStream.prototype.setOnAddTrack = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onaddtrack = cb;
-};
-
-MediaStream.prototype.getOnRemoveTrack = function() {
-  return this.onremovetrack;
-};
-
-MediaStream.prototype.setOnRemoveTrack = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onremovetrack = cb;
-};
 
 function RTCMediaStream(internalMS) {
-  var ms = new MediaStream(internalMS);
+  var that = this;
+
+  EventTarget.call(this);
+
+  internalMS.onactive = function onactive() {
+    that.dispatchEvent(new Event('active'));
+  };
+
+  internalMS.oninactive = function oninactive() {
+    that.dispatchEvent(new Event('inactive'));
+  };
+
+  internalMS.onaddtrack = function onaddtrack(internalMST) {
+    var mst = new RTCMediaStreamTrack(internalMST);
+    that.dispatchEvent(mst);
+  };
+
+  internalMS.onremovetrack = function onremovetrack(internalMST) {
+    var mst = new RTCMediaStreamTrack(internalMST);
+    that.dispatchEvent(mst);
+  };
+
+  var queue = [];
+  var pending = null;
+
+
+  function queueOrRun(obj) {
+    if(null == this._pending) {
+      internalMS[obj.func].apply(internalMS, obj.args);
+
+      if(obj.wait) {
+        pending = obj;
+      }
+    } else {
+      queue.push(obj);
+    }
+  };
+
 
   Object.defineProperties(this, {
     'id': {
       get: function getId() {
-        return ms.getId();
+        return runImmediately({
+          func: 'getId',
+          args: []
+        });
       }
     },
     'inactive': {
       get: function isInactive() {
-        return ms.isInactive();
-      }
-    },
-    'onaddtrack': {
-      get: function() {
-        return ms.getOnAddTrack();
-      },
-      set: function(cb) {
-        ms.setOnAddTrack(cb);
-      }
-    },
-    'onremovetrack': {
-      get: function() {
-        return ms.getOnRemoveTrack();
-      },
-      set: function(cb) {
-        ms.setOnRemoveTrack(cb);
-      }
-    },
-    'onactive': {
-      get: function() {
-        return ms.getOnActive();
-      },
-      set: function(cb) {
-        ms.setOnActive(cb);
-      }
-    },
-    'oninactive': {
-      get: function() {
-        return ms.getOnInactive();
-      },
-      set: function(cb) {
-        ms.setOnInactive(cb);
+        return runImmediately({
+          func: 'isInactive',
+          args: []
+        });
       }
     }
   });
 
   this.getaudiotracks = function getaudiotracks() {
-    return ms.getaudiotracks.apply(ms, arguments);
+    return runImmediately({
+      func: 'getAudioTracks',
+      args: []
+    });
   };
 
   this.getvideotracks = function getvideotracks() {
-    return ms.getvideotracks.apply(ms, arguments);
+    return runImmediately({
+      func: 'getVideoTracks',
+      args: []
+    });
   };
 
-  this.gettrackbyid = function gettrackbyid() {
-    return ms.gettrackbyid.apply(ms, arguments);
+  this.gettrackbyid = function gettrackbyid(id) {
+    return runImmediately({
+      func: 'getTrackById',
+      args: [id]
+    });
   };
 
-  this.addtrack = function addtrack() {
-    ms.addtrack.apply(ms, arguments);
+  this.addtrack = function addtrack(track) {
+    queueOrRun({
+      func: 'addTrack',
+      args: [track._getMST()]
+    });
   };
 
-  this.removetrack = function removetrack() {
-    ms.removetrack.apply(ms, arguments);
+  this.removetrack = function removetrack(track) {
+    queueOrRun({
+      func: 'removeTrack',
+      args: [track._getMST()]
+    });
   };
   
   // FIXME: implement clone
   /*this.clone = function clone() {
-    return ms.clone.apply(ms, arguments);
+    return internalMS.clone();
   };*/
 }
+
 
 module.exports = RTCMediaStream;

--- a/lib/mediastreamtrack.js
+++ b/lib/mediastreamtrack.js
@@ -1,121 +1,45 @@
-function MediaStreamTrack(internalMST) {
-  var that = this;
-  this._mst = internalMST;
+var EventTarget = require('eventtarget');
 
-  this._queue = [];
-  this._pending = null;
-    
-  this._mst.onmute = function onmute() {
-    if(that.onmute && typeof that.onmute == 'function') {
-      that.onmute.apply(that, []);
-    }
-  };
-    
-  this._mst.onunmute = function onunmute() {
-    if(that.onunmute && typeof that.onunmute == 'function') {
-      that.onunmute.apply(that, []);
-    }
-  };
-    
-  this._mst.onstarted = function onstarted() {
-    if(that.onstarted && typeof that.onstarted == 'function') {
-      that.onstarted.apply(that, []);
-    }
-  };
-    
-  this._mst.onended = function onended() {
-    if(that.onended && typeof that.onended == 'function') {
-      that.onended.apply(that, []);
-    }
-  };
+//function MediaStreamTrack(internalMST) {
+//  this._queue = [];
+//  this._pending = null;
+//}
 
-  this.onmute = null;
-  this.onunmute = null;
-  this.onstarted = null;
-  this.onstarted = null;
-}
+//MediaStreamTrack.prototype._getMST = function _getMST() {
+//  if(!this._mst) {
+//    throw new Error('RTCMediaSteamTrack is gone');
+//  }
+//  return this._mst;
+//};
 
-module.exports = MediaStreamTrack;
+//MediaStreamTrack.prototype._queueOrRun = function _queueOrRun(obj) {
+//  var mst = this._getMST();
+//  if(null == this._pending) {
+//    mst[obj.func].apply(mst, obj.args);
+//    if(obj.wait) {
+//      this._pending = obj;
+//    }
+//  } else {
+//    this._queue.push(obj);
+//  }
+//};
 
-MediaStreamTrack.prototype._getMST = function _getMST() {
-  if(!this._mst) {
-    throw new Error('RTCMediaSteamTrack is gone');
-  }
-  return this._mst;
-};
-
-MediaStreamTrack.prototype._queueOrRun = function _queueOrRun(obj) {
-  var mst = this._getMST();
-  if(null == this._pending) {
-    mst[obj.func].apply(mst, obj.args);
-    if(obj.wait) {
-      this._pending = obj;
-    }
-  } else {
-    this._queue.push(obj);
-  }
-};
-
-MediaStreamTrack.prototype._executeNext = function _executeNext() {
-  var obj, mst;
-  mst = this._getMST();
-  if(this._queue.length > 0) {
-    obj = this._queue.shift();
-    mst[obj.func].apply(mst, obj.args);
-    if(obj.wait)
-    {
-      this._pending = obj;
-    } else {
-      this._executeNext();
-    }
-  } else {
-    this._pending = null;
-  }
-};
-
-MediaStreamTrack.prototype.RTCMediaStreamTrackStates = [
-  'initializing',
-  'live',
-  'ended',
-  'failed'
-];
-
-MediaStreamTrack.prototype.getId = function getId() {
-  return this._getMST().id;
-};
-
-MediaStreamTrack.prototype.getKind = function getKind() {
-  return this._getMST().kind;
-};
-
-MediaStreamTrack.prototype.getLabel = function getLabel() {
-  return this._getMST().label;
-};
-
-MediaStreamTrack.prototype.getEnabled = function getEnabled() {
-  return this._getMST().enabled;
-};
-
-MediaStreamTrack.prototype.setEnabled = function setEnabled(enable) {
-  this._getMST().enabled = enable;
-};
-
-MediaStreamTrack.prototype.getMuted = function getMuted() {
-  return this._getMST().muted;
-};
-
-MediaStreamTrack.prototype.getReadOnly = function getReadOnly() {
-  return this._getMST()._readonly;
-};
-
-MediaStreamTrack.prototype.getRemote = function getRemote() {
-  return this._getMST().remote;
-};
-
-MediaStreamTrack.prototype.getReadyState = function getReadyState() {
-  var state = this._getMST().readyState;
-  return this.RTCMediaStreamTrackStates[state];
-};
+//MediaStreamTrack.prototype._executeNext = function _executeNext() {
+//  var obj, mst;
+//  mst = this._getMST();
+//  if(this._queue.length > 0) {
+//    obj = this._queue.shift();
+//    mst[obj.func].apply(mst, obj.args);
+//    if(obj.wait)
+//    {
+//      this._pending = obj;
+//    } else {
+//      this._executeNext();
+//    }
+//  } else {
+//    this._pending = null;
+//  }
+//};
 
 // FIXME: implement stop
 /*MediaStreamTrack.prototype.stop = function stop() {
@@ -127,119 +51,72 @@ MediaStreamTrack.prototype.getReadyState = function getReadyState() {
   return this._getMST().clone();
 };*/
 
-MediaStreamTrack.prototype.getOnStarted = function() {
-  return this.onstarted;
-};
-
-MediaStreamTrack.prototype.setOnStarted = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onstarted = cb;
-};
-
-MediaStreamTrack.prototype.getOnEnded = function() {
-  return this.onended;
-};
-
-MediaStreamTrack.prototype.setOnEnded = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onended = cb;
-};
-
-MediaStreamTrack.prototype.getOnMute = function() {
-  return this.onmute;
-};
-
-MediaStreamTrack.prototype.setOnMute = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onmute = cb;
-};
-
-MediaStreamTrack.prototype.getOnUnmute = function() {
-  return this.onunmute;
-};
-
-MediaStreamTrack.prototype.setOnUnmute = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onunmute = cb;
-};
 
 function RTCMediaStreamTrack(internalMST) {
-  var mst = new MediaStreamTrack(internalMST);
-  
+  var that = this;
+
+  EventTarget.call(this);
+
+  internalMST.onmute = function onmute() {
+    that.dispatchEvent(new Event('mute'));
+  };
+
+  internalMST.onunmute = function onunmute() {
+    that.dispatchEvent(new Event('unmute'));
+  };
+
+  internalMST.onstarted = function onstarted() {
+    that.dispatchEvent(new Event('started'));
+  };
+
+  internalMST.onended = function onended() {
+    that.dispatchEvent(new Event('ended'));
+  };
+
+
   Object.defineProperties(this, {
     'id': {
       get: function getId() {
-        return mst.getId();
+        return internalMST.id;
       }
     },
     'label': {
       get: function getLabel() {
-        return mst.getLabel();
+        return internalMST.label;
       }
     },
     'kind': {
       get: function getKind() {
-        return mst.getKind();
+        return internalMST.kind;
       }
     },
     'enabled': {
       get: function getEnabled() {
-        return mst.getEnabled();
+        return internalMST.enabled;
       },
       set: function setEnabled(enable) {
-        mst.setEnabled(enable);
+        internalMST.enabled = enable;
       }
     },
     'muted': {
       get: function getMuted() {
-        return mst.getMuted();
+        return internalMST.muted;
       }
     },
     '_readonly': {
       get: function getReadOnly() {
-        return mst.getReadOnly();
+        return internalMST._readonly;
       }
     },
     'remote': {
       get: function getRemote() {
-        return mst.getRemote();
+        return internalMST.remote;
       }
     },
     'readyState': {
       get: function getReadyState() {
-        return mst.getReadyState();
-      }
-    },
-    'onstarted': {
-      get: function() {
-        return mst.getOnStarted();
-      },
-      set: function(cb) {
-        mst.setOnStarted(cb);
-      }
-    },
-    'onended': {
-      get: function() {
-        return mst.getOnEnded();
-      },
-      set: function(cb) {
-        mst.setOnEnded(cb);
-      }
-    },
-    'onmute': {
-      get: function() {
-        return mst.getOnMute();
-      },
-      set: function(cb) {
-        mst.setOnMute(cb);
-      }
-    },
-    'onunmute': {
-      get: function() {
-        return mst.getOnUnmute();
-      },
-      set: function(cb) {
-        mst.setOnUnmute(cb);
+        var state = internalMST.readyState;
+        return this.RTCMediaStreamTrackStates[state];
       }
     }
   });
@@ -254,5 +131,14 @@ function RTCMediaStreamTrack(internalMST) {
     return mst.clone.apply(mst, arguments);
   };*/
 }
+
+RTCMediaStreamTrack.prototype.RTCMediaStreamTrackStates =
+[
+  'initializing',
+  'live',
+  'ended',
+  'failed'
+];
+
 
 module.exports = RTCMediaStreamTrack;

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -1,391 +1,200 @@
 var _webrtc = require('bindings')('webrtc.node');
 
+var RTCDataChannel        = require('./datachannel');
+var RTCDataChannelEvent   = require('./datachannelevent');
+var RTCError              = require('./error');
+var RTCIceCandidate       = require('./icecandidate');
+var RTCIceCandidateEvent  = require('./icecandidateevent');
+var RTCMediaStream        = require('./mediastream');
 var RTCSessionDescription = require('./sessiondescription');
-var RTCIceCandidate = require('./icecandidate');
-var RTCError = require('./error');
-var RTCDataChannel = require('./datachannel');
-var RTCMediaStream = require('./mediastream');
-var RTCIceCandidateEvent = require('./icecandidateevent');
-var RTCDataChannelEvent = require('./datachannelevent');
 
-function PeerConnection(configuration, constraints) {
+
+function RTCPeerConnection(configuration, constraints) {
   var that = this;
-  this._pc = new _webrtc.PeerConnection(configuration, constraints);
 
-  this._localType = null;
-  this._remoteType = null;
+  var pc = new _webrtc.PeerConnection(configuration, constraints);
 
-  this._queue = [];
-  this._pending = null;
+  var localType  = null;
+  var remoteType = null;
 
-  this._dataChannels = {};  // open data channels, indexed by label
+  var onaddstream                = null;
+  var onicecandidate             = null;
+  var oniceconnectionstatechange = null;
+  var onicegatheringstatechange  = null;
+  var ondatachannel              = null;
+  var onremovestream             = null;
+  var onsignalingstatechange     = null;
 
-  this._pc.onerror = function onerror() {
-    if(that._pending && that._pending.onError) {
-      that._pending.onError.apply(that, arguments);
-    }
-    that._executeNext();
+  var queue = [];
+  var pending = null;
+
+  var dataChannels = {};  // open data channels, indexed by label
+
+
+  function checkClosed() {
+//    if(this._closed) {
+//      throw new Error('Peer is closed');
+//    }
   };
 
-  this._pc.onsuccess = function onsuccess() {
-    if(that._pending && that._pending.onSuccess) {
-      that._pending.onSuccess.apply(that, arguments);
+  function executeNext() {
+    if(queue.length > 0) {
+      var obj = queue.shift();
+
+      pc[obj.func].apply(pc, obj.args);
+
+      if(obj.wait)
+      {
+        pending = obj;
+      } else {
+        executeNext();
+      }
+    } else {
+      pending = null;
     }
-    that._executeNext();
   };
 
-  this._pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
-    if(that.onicecandidate && typeof that.onicecandidate == 'function') {
+  function queueOrRun(obj) {
+    checkClosed();
+
+    if(null == pending) {
+      pc[obj.func].apply(pc, obj.args);
+
+      if(obj.wait) {
+        pending = obj;
+      }
+    } else {
+      queue.push(obj);
+    }
+  };
+
+  function runImmediately(obj) {
+    checkClosed();
+
+    return pc[obj.func].apply(pc, obj.args);
+  };
+
+
+  //
+  // Attach events to the native PeerConnection object
+  //
+
+  pc.onerror = function onerror() {
+    if(pending && pending.onError) {
+       pending.onError.apply(that, arguments);
+    }
+
+    executeNext();
+  };
+
+  pc.onsuccess = function onsuccess() {
+    if(pending && pending.onSuccess) {
+       pending.onSuccess.apply(that, arguments);
+    }
+
+    executeNext();
+  };
+
+  pc.onicecandidate = function(candidate, sdpMid, sdpMLineIndex) {
+//  pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
+    if(onicecandidate && typeof onicecandidate == 'function') {
       var icecandidate = new RTCIceCandidate({
         'candidate': candidate,
         'sdpMid': sdpMid,
         'sdpMLineIndex': sdpMLineIndex
       });
-      that.onicecandidate.apply(that, [new RTCIceCandidateEvent(icecandidate)]);
+
+      onicecandidate.apply(that, [new RTCIceCandidateEvent(icecandidate)]);
     }
   };
 
-  this._pc.onsignalingstatechange = function onsignalingstatechange(state) {
-    stateString = that.RTCSignalingStates[state];
+  pc.onsignalingstatechange = function onsignalingstatechange(state) {
+    var stateString = that.RTCSignalingStates[state];
+
     if('closed' == stateString) {
-      Object.keys(that._dataChannels).forEach(function(label) {
-        that._dataChannels[label].shutdown();
-        delete that._dataChannels[label];
+      Object.keys(dataChannels).forEach(function(label) {
+        dataChannels[label].shutdown();
+
+        delete dataChannels[label];
       });
     }
-    if(that.onsignalingstatechange && typeof that.onsignalingstatechange == 'function') {
-      that.onsignalingstatechange.apply(that, [stateString]);
+
+    if(onsignalingstatechange && typeof onsignalingstatechange == 'function') {
+       onsignalingstatechange.apply(that, [stateString]);
     }
   };
 
-  this._pc.oniceconnectionstatechange = function oniceconnectionstatechange(state) {
-    if(that.oniceconnectionstatechange && typeof that.oniceconnectionstatechange == 'function') {
-      stateString = that.RTCSignalingStates[state];
-      that.oniceconnectionstatechange.apply(that, [stateString]);
+  pc.oniceconnectionstatechange = function oniceconnectionstatechange(state) {
+    var stateString = that.RTCSignalingStates[state];
+
+    if(oniceconnectionstatechange && typeof oniceconnectionstatechange == 'function') {
+       oniceconnectionstatechange.apply(that, [stateString]);
     }
   };
 
-  this._pc.onicegatheringstatechange = function onicegatheringstatechange(state) {
-    if(that.onicegatheringstatechange && typeof that.onicegatheringstatechange == 'function') {
-      stateString = that.RTCSignalingStates[state];
-      that.onicegatheringstatechange.apply(that, [stateString]);
+  pc.onicegatheringstatechange = function onicegatheringstatechange(state) {
+    var stateString = that.RTCSignalingStates[state];
+
+    if(onicegatheringstatechange && typeof onicegatheringstatechange == 'function') {
+       onicegatheringstatechange.apply(that, [stateString]);
     }
   };
 
-  this._pc.ondatachannel = function ondatachannel(internalDC) {
-    if(that.ondatachannel && typeof that.ondatachannel == 'function') {
-      that._dataChannels[internalDC.label] = internalDC;
+  pc.ondatachannel = function(internalDC) {
+//  pc.ondatachannel = function ondatachannel(internalDC) {
+    if(ondatachannel && typeof ondatachannel == 'function') {
+      dataChannels[internalDC.label] = internalDC;
+
       var dc = new RTCDataChannel(internalDC);
-      that.ondatachannel.apply(that, [new RTCDataChannelEvent(dc)]);
+
+      ondatachannel.apply(that, [new RTCDataChannelEvent(dc)]);
     }
   };
 
-  this._pc.onaddstream = function onaddstream(internalMS) {
-    if(that.onaddstream && typeof that.onaddstream == 'function') {
+  pc.onaddstream = function onaddstream(internalMS) {
+    if(onaddstream && typeof onaddstream == 'function') {
       var ms = new RTCMediaStream(internalMS);
-      that.onaddstream.apply(that, [ms]);
+
+      onaddstream.apply(that, [ms]);
     }
   };
 
-  this._pc.onremovestream = function onremovestream(internalMS) {
-    if(that.onremovestream && typeof that.onremovestream == 'function') {
+  pc.onremovestream = function onremovestream(internalMS) {
+    if(onremovestream && typeof onremovestream == 'function') {
       var ms = new RTCMediaStream(internalMS);
-      that.onremovestream.apply(that, [ms]);
+
+      onremovestream.apply(that, [ms]);
     }
   };
 
-  this.onicecandidate = null;
-  this.onsignalingstatechange = null;
-  this.onicegatheringstatechange = null;
-  this.oniceconnectionstatechange = null;
-  this.ondatachannel = null;
-  this.onaddstream = null;
-  this.onremovestream = null;
-};
 
-PeerConnection.prototype.RTCSignalingStates = [
-  'stable',
-  'have-local-offer',
-  'have-local-pranswer',
-  'have-remote-offer',
-  'have-remote-pranswer',
-  'closed'
-];
-
-PeerConnection.prototype.RTCIceConnectionStates = [
-  'new',
-  'checking',
-  'connected',
-  'completed',
-  'failed',
-  'disconnected',
-  'closed'
-];
-
-PeerConnection.prototype.RTCIceGatheringStates = [
-  'new',
-  'gathering',
-  'complete'
-];
-
-PeerConnection.prototype._getPC = function _getPC() {
-  if(!this._pc) {
-    throw new Error('RTCPeerConnection is gone');
-  }
-  return this._pc;
-};
-
-PeerConnection.prototype._checkClosed = function _checkClosed() {
-  if(this._closed) {
-    throw new Error('Peer is closed');
-  }
-};
-
-PeerConnection.prototype._runImmediately = function _runImmediately(obj) {
-  var pc = this._getPC();
-  this._checkClosed();
-  return pc[obj.func].apply(pc, obj.args);
-}
-
-PeerConnection.prototype._queueOrRun = function _queueOrRun(obj) {
-  var pc = this._getPC();
-  this._checkClosed();
-  if(null == this._pending) {
-    pc[obj.func].apply(pc, obj.args);
-    if(obj.wait) {
-      this._pending = obj;
-    }
-  } else {
-    this._queue.push(obj);
-  }
-};
-
-PeerConnection.prototype._executeNext = function _executeNext() {
-  var obj, pc;
-  pc = this._getPC();
-  if(this._queue.length > 0) {
-    obj = this._queue.shift();
-    pc[obj.func].apply(pc, obj.args);
-    if(obj.wait)
-    {
-      this._pending = obj;
-    } else {
-      this._executeNext();
-    }
-  } else {
-    this._pending = null;
-  }
-};
-
-PeerConnection.prototype.getLocalDescription = function getLocalDescription() {
-  var sdp = this._getPC().localDescription;
-  if(!sdp) {
-    return null;
-  }
-  return new RTCSessionDescription({ type: this._localType,
-                                      sdp: sdp });
-};
-
-PeerConnection.prototype.getRemoteDescription = function getRemoteDescription() {
-  var sdp = this._getPC().remoteDescription;
-  if(!sdp) {
-    return null;
-  }
-  return new RTCSessionDescription({ type: this._remoteType,
-                                      sdp: sdp });
-};
-
-PeerConnection.prototype.getSignalingState = function getSignalingState() {
-  var state = this._getPC().signalingState;
-  return this.RTCSignalingStates[state];
-};
-
-PeerConnection.prototype.getIceGatheringState = function getIceGatheringState() {
-  var state = this._getPC().iceGatheringState;
-  return this.RTCIceGatheringStates[state];
-};
-
-PeerConnection.prototype.getIceConnectionState = function getIceConnectionState() {
-  var state = this._getPC().iceConnectionState;
-  return this.RTCIceConnectionStates[state];
-};
-
-PeerConnection.prototype.getLocalStreams = function getLocalStreams() {
-  return this._getPC().getLocalStreams();
-};
-
-PeerConnection.prototype.getRemoteStreams = function getRemoteStreams() {
-  return this._getPC().getRemoteStreams();
-};
-
-PeerConnection.prototype.getStreamById = function getStreamById(id) {
-  return this._getPC().getStreamById(id);
-};
-
-PeerConnection.prototype.getOnSignalingStateChange = function() {
-  return this.onsignalingstatechange;
-};
-
-PeerConnection.prototype.setOnSignalingStateChange = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onsignalingstatechange = cb;
-};
-
-PeerConnection.prototype.getIceConnectionStateChange = function() {
-  return this.oniceconnectionstatechange;
-};
-
-PeerConnection.prototype.setOnIceConnectionStateChange = function(cb) {
-  this.oniceconnectionstatechange = cb;
-};
-
-PeerConnection.prototype.getOnIceCandidate = function() {
-  return this.onicecandidate;
-};
-
-PeerConnection.prototype.setOnIceCandidate = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onicecandidate = cb;
-};
-
-PeerConnection.prototype.getOnDataChannel = function() {
-  return this.ondatachannel;
-};
-
-PeerConnection.prototype.setOnDataChannel = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.ondatachannel = cb;
-};
-
-PeerConnection.prototype.getOnAddStream = function() {
-  return this.onaddstream;
-};
-
-PeerConnection.prototype.setOnAddStream = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onaddstream = cb;
-};
-
-PeerConnection.prototype.getOnRemoveStream = function() {
-  return this.onremovestream;
-};
-
-PeerConnection.prototype.setOnRemoveStream = function(cb) {
-  // FIXME: throw an exception if cb isn't callable
-  this.onremovestream = cb;
-};
-
-PeerConnection.prototype.createOffer = function createOffer(onSuccess, onError, constraints) {
-  constraints = constraints || {};
-  // FIXME: complain if onError is undefined
-  this._queueOrRun({
-    func: 'createOffer',
-    args: [constraints],
-    wait: true,
-    onSuccess: function(sdp) {
-      onSuccess.call(this, new RTCSessionDescription({type: 'offer', sdp: sdp}));
-    },
-    onError: onError
-  });
-};
-
-PeerConnection.prototype.createAnswer = function createAnswer(onSuccess, onError, constraints) {
-  constraints = constraints || {};
-  // FIXME: complain if onError is undefined
-  this._queueOrRun({
-    func: 'createAnswer',
-    args: [constraints],
-    wait: true,
-    onSuccess: function(sdp) {
-      onSuccess.call(this, new RTCSessionDescription({type: 'answer', sdp: sdp}));
-    },
-    onError: onError
-  });
-};
-
-PeerConnection.prototype.setLocalDescription = function setLocalDescription(sdp, onSuccess, onError) {
-  sdp = sdp || {};
-  this._localType = sdp.type;
-  this._queueOrRun({
-    func: 'setLocalDescription',
-    args: [sdp],
-    wait: true,
-    onSuccess: onSuccess,
-    onError: onError
-  });
-};
-
-PeerConnection.prototype.setRemoteDescription = function setRemoteDescription(sdp, onSuccess, onError) {
-  sdp = sdp || {};
-  this._remoteType = sdp.type;
-  this._queueOrRun({
-    func: 'setRemoteDescription',
-    args: [sdp],
-    wait: true,
-    onSuccess: onSuccess,
-    onError: onError
-  });
-};
-
-PeerConnection.prototype.addIceCandidate = function addIceCandidate(sdp, onSuccess, onError) {
-  sdp = sdp || {};
-  this._queueOrRun({
-    func: 'addIceCandidate',
-    args: [{'candidate': sdp.candidate, 'sdpMid': sdp.sdpMid, 'sdpMLineIndex': sdp.sdpMLineIndex}],
-    wait: true,
-    onSuccess: onSuccess,
-    onError: onError
-  });
-};
-
-PeerConnection.prototype.createDataChannel = function createDataChannel(label, dataChannelDict) {
-  dataChannelDict = dataChannelDict || {};
-  var channel = this._runImmediately({
-    func: 'createDataChannel',
-    args: [label, dataChannelDict]
-  });
-  this._dataChannels[label] = channel;
-  return new RTCDataChannel(channel);
-};
-
-PeerConnection.prototype.addStream = function addStream(stream, constraintsDict) {
-  constraintsDict = constraintsDict || {};
-  this._queueOrRun({
-    func: 'addStream',
-    args: [stream._getMS(), constraintsDict]
-  });
-};
-
-PeerConnection.prototype.removeStream = function removeStream(stream) {
-  this._queueOrRun({
-    func: 'removeStream',
-    args: [stream._getMS()]
-  });
-};
-PeerConnection.prototype.close = function close() {
-  return this._runImmediately({
-    func: 'close',
-    args: []
-  });
-}
-
-function RTCPeerConnection(configuration, constraints) {
-  var pc = new PeerConnection(configuration, constraints);
+  //
+  // PeerConnection properties & attributes
+  //
 
   Object.defineProperties(this, {
     'localDescription': {
       get: function getLocalDescription() {
-        return pc.getLocalDescription();
+        var sdp = pc.localDescription;
+        if(!sdp) {
+          return null;
+        }
+        return new RTCSessionDescription({ type: localType, sdp: sdp });
       }
     },
     'remoteDescription': {
       get: function getRemoteDescription() {
-        return pc.getRemoteDescription();
+        var sdp = pc.remoteDescription;
+        if(!sdp) {
+          return null;
+        }
+        return new RTCSessionDescription({ type: remoteType, sdp: sdp });
       }
     },
     'signalingState': {
       get: function getSignalingState() {
-        return pc.getSignalingState();
+        var state = pc.signalingState;
+        return this.RTCSignalingStates[state];
       }
     },
     'readyState': {
@@ -395,110 +204,223 @@ function RTCPeerConnection(configuration, constraints) {
     },
     'iceGatheringState': {
       get: function getIceGatheringState() {
-        return pc.getIceGatheringState();
+        var state = pc.iceGatheringState;
+        return this.RTCIceGatheringStates[state];
       }
     },
     'iceConnectionState': {
       get: function getIceConnectionState() {
-        return pc.getIceConnectionState();
+        var state = pc.iceConnectionState;
+        return this.RTCIceConnectionStates[state];
       }
     },
+
+    // Event properties
+
     'onsignalingstatechange': {
       get: function() {
-        return pc.getOnSignalingStateChange();
+        return onsignalingstatechange;
       },
       set: function(cb) {
-        pc.setOnSignalingStateChange(cb);
+        // FIXME: throw an exception if cb isn't callable
+        onsignalingstatechange = cb;
       }
     },
     'oniceconnectionstatechange': {
       get: function() {
-        return pc.getIceConnectionStateChange();
+        return oniceconnectionstatechange;
       },
       set: function(cb) {
-        pc.setOnIceConnectionStateChange(cb);
+        oniceconnectionstatechange = cb;
       }
     },
     'onicecandidate': {
       get: function() {
-        return pc.getOnIceCandidate();
+        return onicecandidate;
       },
       set: function(cb) {
-        pc.setOnIceCandidate(cb);
+        // FIXME: throw an exception if cb isn't callable
+        onicecandidate = cb;
       }
     },
     'ondatachannel': {
       get: function() {
-        return pc.getOnDataChannel();
+        return ondatachannel;
       },
       set: function(cb) {
-        pc.setOnDataChannel(cb);
+        // FIXME: throw an exception if cb isn't callable
+        ondatachannel = cb;
       }
     },
     'onaddstream': {
       get: function() {
-        return pc.getOnAddStream();
+        return onaddstream;
       },
       set: function(cb) {
-        pc.setOnAddStream(cb);
+        // FIXME: throw an exception if cb isn't callable
+        onaddstream = cb;
       }
     },
     'onremovestream': {
       get: function() {
-        return pc.getOnRemoveStream();
+        return onremovestream;
       },
       set: function(cb) {
-        pc.setOnRemoveStream(cb);
+        // FIXME: throw an exception if cb isn't callable
+        onremovestream = cb;
       }
     }
   });
 
-  this.createOffer = function createOffer() {
-    return pc.createOffer.apply(pc, arguments);
+
+  //
+  // PeerConnection methods
+  //
+
+  this.createOffer = function createOffer(successCallback, failureCallback, options) {
+    options = options || {};
+
+    // FIXME: complain if onError is undefined
+    queueOrRun({
+      func: 'createOffer',
+      args: [options],
+      wait: true,
+      onSuccess: function(sdp) {
+        successCallback.call(this, new RTCSessionDescription({type: 'offer', sdp: sdp}));
+      },
+      onError: failureCallback
+    });
+
+    return pc.createOffer(arguments);
   };
 
-  this.createAnswer = function createAnswer() {
-    return pc.createAnswer.apply(pc, arguments);
+  this.createAnswer = function createAnswer(successCallback, failureCallback, options) {
+    options = options || {};
+
+    // FIXME: complain if onError is undefined
+    queueOrRun({
+      func: 'createAnswer',
+      args: [options],
+      wait: true,
+      onSuccess: function(sdp) {
+        successCallback.call(this, new RTCSessionDescription({type: 'answer', sdp: sdp}));
+      },
+      onError: failureCallback
+    });
   };
 
-  this.setLocalDescription = function setLocalDescription() {
-    return pc.setLocalDescription.apply(pc, arguments);
+  this.setLocalDescription = function setLocalDescription(description, successCallback, failureCallback) {
+    localType = description.type;
+
+    queueOrRun({
+      func: 'setLocalDescription',
+      args: [description],
+      wait: true,
+      onSuccess: successCallback,
+      onError: failureCallback
+    });
   };
 
-  this.setRemoteDescription = function setRemoteDescription() {
-    return pc.setRemoteDescription.apply(pc, arguments);
+  this.setRemoteDescription = function setRemoteDescription(description, successCallback, failureCallback) {
+    remoteType = description.type;
+
+    queueOrRun({
+      func: 'setRemoteDescription',
+      args: [description],
+      wait: true,
+      onSuccess: successCallback,
+      onError: failureCallback
+    });
   };
 
-  this.addIceCandidate = function addIceCandidate() {
-    return pc.addIceCandidate.apply(pc, arguments);
+  this.addIceCandidate = function addIceCandidate(candidate, successCallback, failureCallback) {
+    queueOrRun({
+      func: 'addIceCandidate',
+      args: [{'candidate':     candidate.candidate,
+              'sdpMid':        candidate.sdpMid,
+              'sdpMLineIndex': candidate.sdpMLineIndex
+             }],
+      wait: true,
+      onSuccess: successCallback,
+      onError: failureCallback
+    });
   };
 
-  this.createDataChannel = function createDataChannel() {
-    return pc.createDataChannel.apply(pc, arguments);
+  this.createDataChannel = function createDataChannel(label, dataChannelDict) {
+    dataChannelDict = dataChannelDict || {};
+
+    var channel = runImmediately({
+      func: 'createDataChannel',
+      args: [label, dataChannelDict]
+    });
+
+    dataChannels[label] = channel;
+    return new RTCDataChannel(channel);
   };
 
-  this.addStream = function addStream() {
-    pc.addStream.apply(pc, arguments);
+  this.addStream = function addStream(stream, constraintsDict) {
+    constraintsDict = constraintsDict || {};
+
+    queueOrRun({
+      func: 'addStream',
+      args: [stream._getMS(), constraintsDict]
+    });
   };
 
-  this.removeStream = function removeStream() {
-    pc.removeStream.apply(pc, arguments);
+  this.removeStream = function removeStream(stream) {
+    queueOrRun({
+      func: 'removeStream',
+      args: [stream._getMS()]
+    });
   };
 
   this.getLocalStreams = function getLocalStreams() {
-    return pc.getLocalStreams.apply(pc, arguments);
+    return pc.getLocalStreams();
   };
 
   this.getRemoteStreams = function getRemoteStreams() {
-    return pc.getRemoteStreams.apply(pc, arguments);
+    return pc.getRemoteStreams();
   };
 
-  this.getStreamById = function getStreamById() {
-    return pc.getStreamById.apply(pc, arguments);
+  this.getStreamById = function getStreamById(streamId) {
+    return pc.getStreamById(streamId);
   };
+
   this.close = function close() {
-    return pc.close.apply(pc, arguments);
-  }
+    return runImmediately({
+      func: 'close',
+      args: []
+    });
+  };
 };
+
+RTCPeerConnection.prototype.RTCIceConnectionStates =
+[
+  'new',
+  'checking',
+  'connected',
+  'completed',
+  'failed',
+  'disconnected',
+  'closed'
+];
+
+RTCPeerConnection.prototype.RTCIceGatheringStates =
+[
+  'new',
+  'gathering',
+  'complete'
+];
+
+RTCPeerConnection.prototype.RTCSignalingStates =
+[
+  'stable',
+  'have-local-offer',
+  'have-local-pranswer',
+  'have-remote-offer',
+  'have-remote-pranswer',
+  'closed'
+];
+
 
 module.exports = RTCPeerConnection;

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -1,5 +1,7 @@
 var _webrtc = require('bindings')('webrtc.node');
 
+var EventTarget = require('eventtarget');
+
 var RTCDataChannel        = require('./datachannel');
 var RTCDataChannelEvent   = require('./datachannelevent');
 var RTCError              = require('./error');
@@ -12,18 +14,12 @@ var RTCSessionDescription = require('./sessiondescription');
 function RTCPeerConnection(configuration, constraints) {
   var that = this;
 
+  EventTarget.call(this);
+
   var pc = new _webrtc.PeerConnection(configuration, constraints);
 
   var localType  = null;
   var remoteType = null;
-
-  var onaddstream                = null;
-  var onicecandidate             = null;
-  var oniceconnectionstatechange = null;
-  var onicegatheringstatechange  = null;
-  var ondatachannel              = null;
-  var onremovestream             = null;
-  var onsignalingstatechange     = null;
 
   var queue = [];
   var pending = null;
@@ -95,17 +91,14 @@ function RTCPeerConnection(configuration, constraints) {
     executeNext();
   };
 
-  pc.onicecandidate = function(candidate, sdpMid, sdpMLineIndex) {
-//  pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
-    if(onicecandidate && typeof onicecandidate == 'function') {
-      var icecandidate = new RTCIceCandidate({
-        'candidate': candidate,
-        'sdpMid': sdpMid,
-        'sdpMLineIndex': sdpMLineIndex
-      });
+  pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
+    var icecandidate = new RTCIceCandidate({
+      'candidate': candidate,
+      'sdpMid': sdpMid,
+      'sdpMLineIndex': sdpMLineIndex
+    });
 
-      onicecandidate.apply(that, [new RTCIceCandidateEvent(icecandidate)]);
-    }
+    that.dispatchEvent(new RTCIceCandidateEvent(icecandidate));
   };
 
   pc.onsignalingstatechange = function onsignalingstatechange(state) {
@@ -119,52 +112,39 @@ function RTCPeerConnection(configuration, constraints) {
       });
     }
 
-    if(onsignalingstatechange && typeof onsignalingstatechange == 'function') {
-       onsignalingstatechange.apply(that, [stateString]);
-    }
+   that.dispatchEvent(stateString);
   };
 
   pc.oniceconnectionstatechange = function oniceconnectionstatechange(state) {
     var stateString = that.RTCSignalingStates[state];
 
-    if(oniceconnectionstatechange && typeof oniceconnectionstatechange == 'function') {
-       oniceconnectionstatechange.apply(that, [stateString]);
-    }
+    that.dispatchEvent(stateString);
   };
 
   pc.onicegatheringstatechange = function onicegatheringstatechange(state) {
     var stateString = that.RTCSignalingStates[state];
 
-    if(onicegatheringstatechange && typeof onicegatheringstatechange == 'function') {
-       onicegatheringstatechange.apply(that, [stateString]);
-    }
+    that.dispatchEvent(stateString);
   };
 
-  pc.ondatachannel = function(internalDC) {
-//  pc.ondatachannel = function ondatachannel(internalDC) {
-    if(ondatachannel && typeof ondatachannel == 'function') {
-      dataChannels[internalDC.label] = internalDC;
+  pc.ondatachannel = function ondatachannel(internalDC) {
+    dataChannels[internalDC.label] = internalDC;
 
-      var dc = new RTCDataChannel(internalDC);
+    var dc = new RTCDataChannel(internalDC);
 
-      ondatachannel.apply(that, [new RTCDataChannelEvent(dc)]);
-    }
+    that.dispatchEvent(new RTCDataChannelEvent(dc));
   };
 
   pc.onaddstream = function onaddstream(internalMS) {
-    if(onaddstream && typeof onaddstream == 'function') {
-      var ms = new RTCMediaStream(internalMS);
+    var ms = new RTCMediaStream(internalMS);
 
-      onaddstream.apply(that, [ms]);
-    }
+    that.dispatchEvent(ms);
   };
 
   pc.onremovestream = function onremovestream(internalMS) {
-    if(onremovestream && typeof onremovestream == 'function') {
-      var ms = new RTCMediaStream(internalMS);
+    var ms = new RTCMediaStream(internalMS);
 
-      onremovestream.apply(that, [ms]);
-    }
+    that.dispatchEvent(ms);
   };
 
 
@@ -212,62 +192,6 @@ function RTCPeerConnection(configuration, constraints) {
       get: function getIceConnectionState() {
         var state = pc.iceConnectionState;
         return this.RTCIceConnectionStates[state];
-      }
-    },
-
-    // Event properties
-
-    'onsignalingstatechange': {
-      get: function() {
-        return onsignalingstatechange;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onsignalingstatechange = cb;
-      }
-    },
-    'oniceconnectionstatechange': {
-      get: function() {
-        return oniceconnectionstatechange;
-      },
-      set: function(cb) {
-        oniceconnectionstatechange = cb;
-      }
-    },
-    'onicecandidate': {
-      get: function() {
-        return onicecandidate;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onicecandidate = cb;
-      }
-    },
-    'ondatachannel': {
-      get: function() {
-        return ondatachannel;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        ondatachannel = cb;
-      }
-    },
-    'onaddstream': {
-      get: function() {
-        return onaddstream;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onaddstream = cb;
-      }
-    },
-    'onremovestream': {
-      get: function() {
-        return onremovestream;
-      },
-      set: function(cb) {
-        // FIXME: throw an exception if cb isn't callable
-        onremovestream = cb;
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
   },
   "dependencies": {
     "bindings": "~1.1.1",
-    "node-gyp": "~0.10.10",
+    "eventtarget": "0.0.0",
     "nan": "~0.4.4",
+    "node-gyp": "~0.10.10",
     "rsvp": "~3.0.3"
   },
   "devDependencies": {
-    "tape": "~2.4.2",
-    "ws": "~0.4.31",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.6.*",
-    "grunt-tape": "~0.0.2"
+    "grunt-tape": "~0.0.2",
+    "tape": "~2.4.2",
+    "ws": "~0.4.31"
   },
   "scripts": {
     "install": "node bin/build.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "bindings": "~1.1.1",
-    "eventtarget": "0.0.0",
+    "eventtarget": "~0.0.1",
     "nan": "~0.4.4",
     "node-gyp": "~0.10.10",
     "rsvp": "~3.0.3"


### PR DESCRIPTION
Here you have an example of my proposal to unify internal and public classes, in this case done with the PeerConnection one. As a result of it, not only the code is almost 100 lines smaller and gets simpler and cleaner and more easier to maintain and expand (adding EventTarget events will be trivial), but also it will waste less memory and there are no private attributes accesibles from outside, making it more secure and standard compliant. I have updated the methods parameters names to the current ones on the specification. For the native PeerConnection events onicecandidate and ondatachannel I needed to remove the function names due to conflicts that provocated an infinite recursion, but this will be fixed when EventTarget events get implemented.

Opinions? Comments? Suggestions? If you agree, I can keep working on adding the EventTarget events on this and apply the same code scheme to the other public classes.
