### PR TITLE
Linting js files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,13 +13,13 @@ module.exports = function(grunt) {
       },
       lib: {
         src: [
-          /*'lib/**.js',*/
+          'lib/**.js',
           'bin/**.js'
         ]
       },
       test: {
         src: [
-          /*'test/**.js'*/
+          'test/**.js'
         ]
       }
     },

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -2,7 +2,6 @@ var RTCIceCandidate       = window.mozRTCIceCandidate       || window.webkitRTCI
 var RTCPeerConnection     = window.mozRTCPeerConnection     || window.webkitRTCPeerConnection     || window.RTCPeerConnection;
 var RTCSessionDescription = window.mozRTCSessionDescription || window.webkitRTCSessionDescription || window.RTCSessionDescription;
 
-
 exports.RTCIceCandidate       = RTCIceCandidate;
 exports.RTCPeerConnection     = RTCPeerConnection;
 exports.RTCSessionDescription = RTCSessionDescription;

--- a/lib/datachannel.js
+++ b/lib/datachannel.js
@@ -1,7 +1,5 @@
-var EventTarget = require('eventtarget');
-
-var RTCDataChannelMessageEvent = require('./datachannelmessageevent');
-
+var EventTarget = require('eventtarget')
+  , RTCDataChannelMessageEvent = require('./datachannelmessageevent');
 
 //function DataChannel(internalDC) {
 //  this._queue = [];
@@ -51,10 +49,10 @@ var RTCDataChannelMessageEvent = require('./datachannelmessageevent');
 
 
 function RTCDataChannel(internalDC) {
+  'use strict';
   var that = this;
 
   EventTarget.call(this);
-
 
   internalDC.onerror = function onerror() {
     that.dispatchEvent({type: 'error'});
@@ -70,14 +68,13 @@ function RTCDataChannel(internalDC) {
     switch(state) {
       case 'open':
         that.dispatchEvent({type: 'open'});
-      break;
+        break;
 
       case 'closed':
         that.dispatchEvent({type: 'close'});
-      break;
+        break;
     }
   };
-
 
   Object.defineProperties(this, {
     'label': {
@@ -112,21 +109,18 @@ function RTCDataChannel(internalDC) {
   this.close = function close() {
     internalDC.close();
   };
-};
+}
 
-RTCDataChannel.prototype.RTCDataStates =
-[
+RTCDataChannel.prototype.RTCDataStates = [
   'connecting',
   'open',
   'closing',
   'closed'
 ];
 
-RTCDataChannel.prototype.BinaryTypes =
-[
+RTCDataChannel.prototype.BinaryTypes = [
   'blob',  // Note: not sure what to do about this, since node doesn't have a Blob API
   'arraybuffer'
 ];
-
 
 module.exports = RTCDataChannel;

--- a/lib/datachannelevent.js
+++ b/lib/datachannelevent.js
@@ -1,5 +1,5 @@
-function RTCDataChannelEvent(type, eventInitDict)
-{
+function RTCDataChannelEvent(type, eventInitDict) {
+  'use strict';
   Object.defineProperties(this, {
     'type': {
       value: type,
@@ -10,7 +10,6 @@ function RTCDataChannelEvent(type, eventInitDict)
       enumerable: true
     }
   });
-};
-
+}
 
 module.exports = RTCDataChannelEvent;

--- a/lib/datachannelmessageevent.js
+++ b/lib/datachannelmessageevent.js
@@ -1,7 +1,7 @@
 function RTCDataChannelMessageEvent(message) {
+  'use strict';
   this.data = message;
 }
 RTCDataChannelMessageEvent.prototype.type = 'message';
-
 
 module.exports = RTCDataChannelMessageEvent;

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,20 +1,21 @@
 function RTCError(code, message) {
+  'use strict';
   this.name = this.reasonName[Math.min(code, this.reasonName.length - 1)];
-  this.message = (typeof message === "string")? message : this.name;
+  this.message = (typeof message === 'string')? message : this.name;
 }
 
 module.exports = RTCError;
 
 RTCError.prototype.reasonName = [
   // These strings must match those defined in the WebRTC spec.
-  "NO_ERROR", // Should never happen -- only used for testing
-  "INVALID_CONSTRAINTS_TYPE",
-  "INVALID_CANDIDATE_TYPE",
-  "INVALID_MEDIASTREAM_TRACK",
-  "INVALID_STATE",
-  "INVALID_SESSION_DESCRIPTION",
-  "INCOMPATIBLE_SESSION_DESCRIPTION",
-  "INCOMPATIBLE_CONSTRAINTS",
-  "INCOMPATIBLE_MEDIASTREAMTRACK",
-  "INTERNAL_ERROR"
+  'NO_ERROR', // Should never happen -- only used for testing
+  'INVALID_CONSTRAINTS_TYPE',
+  'INVALID_CANDIDATE_TYPE',
+  'INVALID_MEDIASTREAM_TRACK',
+  'INVALID_STATE',
+  'INVALID_SESSION_DESCRIPTION',
+  'INCOMPATIBLE_SESSION_DESCRIPTION',
+  'INCOMPATIBLE_CONSTRAINTS',
+  'INCOMPATIBLE_MEDIASTREAMTRACK',
+  'INTERNAL_ERROR'
 ];

--- a/lib/icecandidate.js
+++ b/lib/icecandidate.js
@@ -1,6 +1,6 @@
 function RTCIceCandidate(candidateInitDict) {
-  if(candidateInitDict)
-  {
+  'use strict';
+  if(candidateInitDict) {
     this.candidate     = candidateInitDict.candidate;
     this.sdpMid        = candidateInitDict.sdpMid;
     this.sdpMLineIndex = candidateInitDict.sdpMLineIndex;

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -30,7 +30,10 @@ var MediaStreamTrack      = require('./mediastreamtrack');
 
 
 function MediaStream(internalMS) {
-  var that = this;
+  'use strict';
+  var that = this
+    , queue = []
+    , pending = null;
 
   EventTarget.call(this);
 
@@ -56,13 +59,8 @@ function MediaStream(internalMS) {
 
   // [ToDo] onended
 
-
-  var queue = [];
-  var pending = null;
-
-
   function queueOrRun(obj) {
-    if(null == this._pending) {
+    if(null === that.pending) {
       internalMS[obj.func].apply(internalMS, obj.args);
 
       if(obj.wait) {
@@ -71,8 +69,7 @@ function MediaStream(internalMS) {
     } else {
       queue.push(obj);
     }
-  };
-
+  }
 
   Object.defineProperties(this, {
     'id': {
@@ -127,12 +124,11 @@ function MediaStream(internalMS) {
       args: [track._getMST()]
     });
   };
-  
+
   // FIXME: implement clone
   /*this.clone = function clone() {
     return internalMS.clone();
   };*/
 }
-
 
 module.exports = MediaStream;

--- a/lib/mediastreamevent.js
+++ b/lib/mediastreamevent.js
@@ -1,5 +1,5 @@
-function MediaStreamEvent(type, eventInitDict)
-{
+function MediaStreamEvent(type, eventInitDict) {
+  'use strict';
   Object.defineProperties(this, {
     'type': {
       value: type,
@@ -10,7 +10,6 @@ function MediaStreamEvent(type, eventInitDict)
       enumerable: true
     }
   });
-};
-
+}
 
 module.exports = MediaStreamEvent;

--- a/lib/mediastreamtrack.js
+++ b/lib/mediastreamtrack.js
@@ -53,6 +53,7 @@ var EventTarget = require('eventtarget');
 
 
 function MediaStreamTrack(internalMST) {
+  'use strict';
   var that = this;
 
   EventTarget.call(this);
@@ -74,7 +75,6 @@ function MediaStreamTrack(internalMST) {
   };
 
   // [ToDo] onoverconstrained
-
 
   Object.defineProperties(this, {
     'id': {
@@ -122,7 +122,7 @@ function MediaStreamTrack(internalMST) {
       }
     }
   });
-  
+
   // FIXME: implement stop
   /*this.stop = function stop() {
     return mst.stop.apply(mst, arguments);
@@ -134,13 +134,11 @@ function MediaStreamTrack(internalMST) {
   };*/
 }
 
-MediaStreamTrack.prototype.MediaStreamTrackStates =
-[
+MediaStreamTrack.prototype.MediaStreamTrackStates = [
   'initializing',
   'live',
   'ended',
   'failed'
 ];
-
 
 module.exports = MediaStreamTrack;

--- a/lib/mediastreamtrackevent.js
+++ b/lib/mediastreamtrackevent.js
@@ -1,5 +1,5 @@
-function MediaStreamTrackEvent(type, eventInitDict)
-{
+function MediaStreamTrackEvent(type, eventInitDict) {
+  'use strict';
   Object.defineProperties(this, {
     'type': {
       value: type,
@@ -10,7 +10,6 @@ function MediaStreamTrackEvent(type, eventInitDict)
       enumerable: true
     }
   });
-};
-
+}
 
 module.exports = MediaStreamTrackEvent;

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -1,38 +1,30 @@
-var _webrtc = require('bindings')('webrtc.node');
-
-var EventTarget = require('eventtarget');
-
-var MediaStream               = require('./mediastream');
-var MediaStreamEvent          = require('./mediastreamevent');
-var RTCDataChannel            = require('./datachannel');
-var RTCDataChannelEvent       = require('./datachannelevent');
-var RTCError                  = require('./error');
-var RTCIceCandidate           = require('./icecandidate');
-var RTCPeerConnectionIceEvent = require('./rtcpeerconnectioniceevent');
-var RTCSessionDescription     = require('./sessiondescription');
-
+var _webrtc = require('bindings')('webrtc.node')
+  , EventTarget = require('eventtarget')
+  , MediaStream = require('./mediastream')
+  , MediaStreamEvent = require('./mediastreamevent')
+  , RTCDataChannel = require('./datachannel')
+  , RTCDataChannelEvent = require('./datachannelevent')
+  , RTCIceCandidate = require('./icecandidate')
+  , RTCPeerConnectionIceEvent = require('./rtcpeerconnectioniceevent')
+  , RTCSessionDescription = require('./sessiondescription');
 
 function RTCPeerConnection(configuration, constraints) {
-  var that = this;
+  'use strict';
+  var that = this
+    , pc = new _webrtc.PeerConnection(configuration, constraints)
+    , localType = null
+    , remoteType = null
+    , queue = []
+    , pending = null
+    , dataChannels = {};  // open data channels, indexed by label
 
   EventTarget.call(this);
-
-  var pc = new _webrtc.PeerConnection(configuration, constraints);
-
-  var localType  = null;
-  var remoteType = null;
-
-  var queue = [];
-  var pending = null;
-
-  var dataChannels = {};  // open data channels, indexed by label
-
 
   function checkClosed() {
 //    if(this._closed) {
 //      throw new Error('Peer is closed');
 //    }
-  };
+  }
 
   function executeNext() {
     if(queue.length > 0) {
@@ -49,12 +41,12 @@ function RTCPeerConnection(configuration, constraints) {
     } else {
       pending = null;
     }
-  };
+  }
 
   function queueOrRun(obj) {
     checkClosed();
 
-    if(null == pending) {
+    if(null === pending) {
       pc[obj.func].apply(pc, obj.args);
 
       if(obj.wait) {
@@ -63,14 +55,13 @@ function RTCPeerConnection(configuration, constraints) {
     } else {
       queue.push(obj);
     }
-  };
+  }
 
   function runImmediately(obj) {
     checkClosed();
 
     return pc[obj.func].apply(pc, obj.args);
-  };
-
+  }
 
   //
   // Attach events to the native PeerConnection object
@@ -78,7 +69,7 @@ function RTCPeerConnection(configuration, constraints) {
 
   pc.onerror = function onerror() {
     if(pending && pending.onError) {
-       pending.onError.apply(that, arguments);
+      pending.onError.apply(that, arguments);
     }
 
     executeNext();
@@ -86,12 +77,11 @@ function RTCPeerConnection(configuration, constraints) {
 
   pc.onsuccess = function onsuccess() {
     if(pending && pending.onSuccess) {
-       pending.onSuccess.apply(that, arguments);
+      pending.onSuccess.apply(that, arguments);
     }
 
     executeNext();
   };
-
 
   pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
     var icecandidate = new RTCIceCandidate({
@@ -106,7 +96,7 @@ function RTCPeerConnection(configuration, constraints) {
   pc.onsignalingstatechange = function onsignalingstatechange(state) {
     var stateString = that.RTCSignalingStates[state];
 
-    if('closed' == stateString) {
+    if('closed' === stateString) {
       Object.keys(dataChannels).forEach(function(label) {
         dataChannels[label].shutdown();
 
@@ -114,7 +104,7 @@ function RTCPeerConnection(configuration, constraints) {
       });
     }
 
-   that.dispatchEvent({type: stateString});
+    that.dispatchEvent({type: stateString});
   };
 
   pc.oniceconnectionstatechange = function oniceconnectionstatechange(state) {
@@ -150,7 +140,6 @@ function RTCPeerConnection(configuration, constraints) {
 
     that.dispatchEvent(new MediaStreamEvent('removestream', {stream: ms}));
   };
-
 
   //
   // PeerConnection properties & attributes
@@ -199,7 +188,6 @@ function RTCPeerConnection(configuration, constraints) {
       }
     }
   });
-
 
   //
   // PeerConnection methods
@@ -320,10 +308,9 @@ function RTCPeerConnection(configuration, constraints) {
       args: []
     });
   };
-};
+}
 
-RTCPeerConnection.prototype.RTCIceConnectionStates =
-[
+RTCPeerConnection.prototype.RTCIceConnectionStates = [
   'new',
   'checking',
   'connected',
@@ -333,15 +320,13 @@ RTCPeerConnection.prototype.RTCIceConnectionStates =
   'closed'
 ];
 
-RTCPeerConnection.prototype.RTCIceGatheringStates =
-[
+RTCPeerConnection.prototype.RTCIceGatheringStates = [
   'new',
   'gathering',
   'complete'
 ];
 
-RTCPeerConnection.prototype.RTCSignalingStates =
-[
+RTCPeerConnection.prototype.RTCSignalingStates = [
   'stable',
   'have-local-offer',
   'have-local-pranswer',

--- a/lib/rtcpeerconnectioniceevent.js
+++ b/lib/rtcpeerconnectioniceevent.js
@@ -1,5 +1,5 @@
-function RTCPeerConnectionIceEvent(type, eventInitDict)
-{
+function RTCPeerConnectionIceEvent(type, eventInitDict) {
+  'use strict';
   Object.defineProperties(this, {
     'type': {
       value: type,
@@ -11,6 +11,5 @@ function RTCPeerConnectionIceEvent(type, eventInitDict)
     }
   });
 }
-
 
 module.exports = RTCPeerConnectionIceEvent;

--- a/lib/sessiondescription.js
+++ b/lib/sessiondescription.js
@@ -1,9 +1,9 @@
 function RTCSessionDescription(descriptionInitDict) {
-  if(descriptionInitDict)
-  {
+  'use strict';
+  if(descriptionInitDict) {
     this.type = descriptionInitDict.type;
-    this.sdp  = descriptionInitDict.sdp;
+    this.sdp = descriptionInitDict.sdp;
   }
-};
+}
 
 module.exports = RTCSessionDescription;

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,3 +1,4 @@
+'use strict';
 var test = require('tape');
 
 // var detect = require('rtc-core/detect');
@@ -187,7 +188,7 @@ test('data channel connectivity', function(t) {
   dcs[1].onmessage = function(evt) {
     var data = evt.data && new Uint8Array(evt.data);
 
-    t.ok(data && typeof data.length != 'undefined', 'got valid data');
+    t.ok(data && typeof data.length !== 'undefined', 'got valid data');
     t.equal(data.length, 2, 'two bytes sent');
     t.equal(data[0], 10, 'byte:0 matches expected');
     t.equal(data[1], 11, 'byte:1 matches expected');

--- a/test/create-offer.js
+++ b/test/create-offer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var test = require('tape');
 
 var RTCPeerConnection = require('..').RTCPeerConnection;

--- a/test/sessiondesc.js
+++ b/test/sessiondesc.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var test = require('tape');
 
 var wrtc = require('..');


### PR DESCRIPTION
Hi,
as in the comment this PR contains a linted collection of files.
Short recap:
- as reported in the commit message there's a `runImmediately()` method that isn't defined in the file where it's used (I see that the definition is in the `peerconnection.js`);
- there was in `mediastream.js` line 65 a reference to a `_pending` variable but the variable name was `pending`. I thought that it was a typo.

Imho there's the need of a little refactor to expose the `runImmediately()`.
As usual open for review.
