### PR TITLE
examples/bridge.js now serves static files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Benjamin Byholm <bbyholm@abo.fi>
 Alex Londeree <alex.londeree@gmail.com>
 Jesús Leganés Combarro "piranna" <piranna@gmail.com>
 Dario Andrei <wouldgo84@gmail.com>
+Matt Porritt <mattp@catalyst-au.net>

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Once everything is built, try `npm test` as a sanity check.
 
 ## bridge.js
 You can run the data channel demo by `node examples/bridge.js` and browsing to `examples/peer.html` in `chrome --enable-data-channels`.
+
 usage:
 ````
 node examples/bridge.js [-h <host>] [-p <port>] [-ws <ws port>]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,26 @@ npm install
 
 # Tests
 
-Once everything is built, try `npm test` as a sanity check. You can run the data channel demo by `node examples/bridge.js` and browsing to `examples/peer.html` in `chrome --enable-data-channels`. You can pass an alternate port to the node script by `node examples/bridge.js <port>`. If the bridge and peer are on different machines, you can pass the bridge address to the peer by `http://<yourmachine>/peer.html?<host:port>`.
+Once everything is built, try `npm test` as a sanity check.
+
+## bridge.js
+You can run the data channel demo by `node examples/bridge.js` and browsing to `examples/peer.html` in `chrome --enable-data-channels`.
+usage:
+````
+node examples/bridge.js [-h <host>] [-p <port>] [-ws <ws port>]
+````
+options:
+````
+-h  host IP for the webserver that will serve the static files (default 127.0.0.1)
+-p  host port for the webserver that will serve the static files (default 8080)
+-ws port of the Web Socket server (default 9001)
+````
+
+If the bridge and peer are on different machines, you can pass the bridge address to the peer by: 
+````
+http://<webserver>/peer.html?<sockertserver:port>
+````
+By default the bridge will be the same IP as the webserver and will listen on port 9001.
 
 The output from `bridge.js` should look like:
 ````

--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -1,7 +1,9 @@
+var static = require('node-static-alias');
 var http = require('http');
 var webrtc = require('..');
 var ws = require('ws');
 
+var args = require('minimist')(process.argv.slice(2));
 var MAX_REQUEST_LENGHT = 1024;
 var pc = null;
 var offer = null;
@@ -26,10 +28,28 @@ var pendingDataChannels = {};
 var dataChannels = {}
 var pendingCandidates = [];
 
-var args = process.argv;
-var port = args[2] || 9001;
+var host = args.h || '127.0.0.1';
+var port = args.p || 8080;
+var socketPort = args.ws || 9001;
 
-var wss = new ws.Server({'port': port});
+var file = new static.Server('./examples', {
+    alias: {
+        match: '/dist/wrtc.js',
+        serve: '../dist/wrtc.js',
+        allowOutside: true
+      }
+    });
+
+var app = http.createServer(function (req, res) {
+    console.log(req.url);
+    req.addListener('end', function() {
+        file.serve(req, res);
+      }).resume();
+
+}).listen(port, host);
+console.log('Server running at http://' + host + ':' + port + '/');
+
+var wss = new ws.Server({'port': 9001});
 wss.on('connection', function(ws)
 {
   console.info('ws connected');

--- a/examples/peer.js
+++ b/examples/peer.js
@@ -1,6 +1,7 @@
 (function() {
 
-var bridge = window.location.toString().split('?')[1] || 'localhost:9001';
+var host = window.location.host.split(':')[0];
+var bridge = window.location.toString().split('?')[1] || host + ':9001';
 
 var RTCPeerConnection     = wrtc.RTCPeerConnection;
 var RTCSessionDescription = wrtc.RTCSessionDescription;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
     "grunt-tape": "~0.0.2",
     "tape": "~2.4.2",
     "ws": "~0.4.31",
-    "aws-sdk": "^2.0.0-rc13"
+    "aws-sdk": "^2.0.0-rc13",
+    "node-static": "^0.7.3",
+    "minimist": "0.0.8",
+    "node-static-alias": "^0.1.0"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",


### PR DESCRIPTION
A minor change to help hacks like me with testing.
Altered examples/bridge to also support serving static files to make running the example easier.  More CLI arguments are supported.
Updated documentation and package dependencies to support updated example
