### PR TITLE
Return empty arrays while the underlying implementation is incomplete

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -300,11 +300,11 @@ function RTCPeerConnection(configuration, constraints) {
   };
 
   this.getLocalStreams = function getLocalStreams() {
-    return pc.getLocalStreams();
+    return []; // pc.getLocalStreams();
   };
 
   this.getRemoteStreams = function getRemoteStreams() {
-    return pc.getRemoteStreams();
+    return []; // pc.getRemoteStreams();
   };
 
   this.getStreamById = function getStreamById(streamId) {


### PR DESCRIPTION
Just a really minor patch to redirect the call from the underlying binding while the implementation is incomplete.  Basically, I finally got around to writing an rtc.io plugin for the node bindings and because rtc-quickconnect looks for remote streams once connected an error occurs when attempting to talk to the bindings.

More info on the node plugin here:
https://github.com/rtc-io/rtc-plugin-node

I still need to push the changes to rtc-signaller up to npm, but you can clone the plugin repo and play around if you are interested :)
