### PR TITLE
Fix race condition in tests, seen on Arch

### DIFF
--- a/test/connect.js
+++ b/test/connect.js
@@ -159,7 +159,8 @@ test('monitor the ice connection state of peer:0', function(t) {
   t.plan(1);
 
   function checkState() {
-    if (peers[0].iceConnectionState === 'connected') {
+    if (peers[0].iceConnectionState === 'connected' ||
+        peers[0].iceConnectionState === 'completed') {
       t.pass('peer:0 in connected state');
       peers[0].oniceconnectionstatechange = null;
     }


### PR DESCRIPTION
Valid iceConnectionStates after connection are `connected` and `completed`¹, but our test only checked for `connected`.  For some reason, on Arch the final `oniceconnectionstatechange()` happens before we test, with the result that (a) we're now in `completed`, and (b) `oniceconnectionstatechange()` is not going to be called again, because the connection is already in its final connected state.  As a result, we hang forever waiting for it to change to "connected".  But the connection is working fine, and the subsequent tests will pass.

This patch fixes the tests on both Ubuntu 14.04 (where the test runs while the state is `connected`) and Arch 2014.06 (where the test runs while the state is `completed`).  There's a Chrome bug that looks relevant² (it mentions the same workaround this patch uses), and we also discussed this bug in PR #123.

¹ http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtciceconnectionstate-enum
² https://code.google.com/p/chromium/issues/detail?id=371799
