### PR TITLE
Add getUserMedia support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -235,8 +235,9 @@
         'src/set-remote-description-observer.cc',
         'src/peerconnection.cc',
         'src/datachannel.cc',
-#        'src/mediastream.cc',
-#        'src/mediastreamtrack.cc',
+        'src/mediastream.cc',
+        'src/mediastreamtrack.cc',
+        'src/getusermedia.cc'
       ]
     },
     {

--- a/lib/getusermedia.js
+++ b/lib/getusermedia.js
@@ -1,0 +1,16 @@
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+var _webrtc = require(binding_path);
+
+var MediaStream = require('./mediastream');
+
+function getUserMedia(constraints, successCallback, errorCallback) {
+  var stream = _webrtc.getUserMedia(constraints);
+  if (stream === null) {
+    return errorCallback(new Error("Couldn't create MediaStream"));
+  }
+  successCallback(new MediaStream(stream));
+}
+
+module.exports = getUserMedia;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+exports.getUserMedia          = require('./getusermedia');
 exports.RTCIceCandidate       = require('./icecandidate');
 exports.RTCPeerConnection     = require('./peerconnection');
 exports.RTCSessionDescription = require('./sessiondescription');

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -3,32 +3,6 @@ var EventTarget = require('./eventtarget');
 var MediaStreamTrackEvent = require('./mediastreamtrackevent');
 var MediaStreamTrack      = require('./mediastreamtrack');
 
-
-//MediaStream.prototype._getMS = function _getMS() {
-//  if(!this._ms) {
-//    throw new Error('RTCMediaSteam is gone');
-//  }
-//  return this._ms;
-//};
-
-//MediaStream.prototype._executeNext = function _executeNext() {
-//  var obj, ms;
-//  ms = this._getMS();
-//  if(this._queue.length > 0) {
-//    obj = this._queue.shift();
-//    ms[obj.func].apply(ms, obj.args);
-//    if(obj.wait)
-//    {
-//      this._pending = obj;
-//    } else {
-//      this._executeNext();
-//    }
-//  } else {
-//    this._pending = null;
-//  }
-//};
-
-
 function MediaStream(internalMS) {
   'use strict';
   var that = this
@@ -37,13 +11,13 @@ function MediaStream(internalMS) {
 
   EventTarget.call(this);
 
-//  internalMS.onactive = function onactive() {
-//    that.dispatchEvent({type: 'active'});
-//  };
-//
-//  internalMS.oninactive = function oninactive() {
-//    that.dispatchEvent({type: 'inactive'});
-//  };
+  internalMS.onactive = function onactive() {
+    that.dispatchEvent({type: 'active'});
+  };
+
+  internalMS.oninactive = function oninactive() {
+    that.dispatchEvent({type: 'inactive'});
+  };
 
   internalMS.onaddtrack = function onaddtrack(internalMST) {
     var mst = new MediaStreamTrack(internalMST);
@@ -59,70 +33,41 @@ function MediaStream(internalMS) {
 
   // [ToDo] onended
 
-  function queueOrRun(obj) {
-    if(null === that.pending) {
-      internalMS[obj.func].apply(internalMS, obj.args);
-
-      if(obj.wait) {
-        pending = obj;
-      }
-    } else {
-      queue.push(obj);
-    }
-  }
-
   Object.defineProperties(this, {
     'id': {
       get: function getId() {
-        return runImmediately({
-          func: 'getId',
-          args: []
-        });
+        return internalMS.id;
       }
     },
     'inactive': {
       get: function isInactive() {
-        return runImmediately({
-          func: 'isInactive',
-          args: []
-        });
+        return internalMS.isinactive;
       }
     }
   });
 
-  this.getaudiotracks = function getaudiotracks() {
-    return runImmediately({
-      func: 'getAudioTracks',
-      args: []
-    });
+  this._getMS = function _getMS() {
+    return internalMS;
   };
 
-  this.getvideotracks = function getvideotracks() {
-    return runImmediately({
-      func: 'getVideoTracks',
-      args: []
-    });
+  this.getAudioTracks = function getAudioTracks() {
+    return internalMS.getAudioTracks();
   };
 
-  this.gettrackbyid = function gettrackbyid(id) {
-    return runImmediately({
-      func: 'getTrackById',
-      args: [id]
-    });
+  this.getVideoTracks = function getVideoTracks() {
+    return internalMS.getVideoTracks();
   };
 
-  this.addtrack = function addtrack(track) {
-    queueOrRun({
-      func: 'addTrack',
-      args: [track._getMST()]
-    });
+  this.getTrackById = function getTrackById(id) {
+    return internalMS.getTrackById(id);
   };
 
-  this.removetrack = function removetrack(track) {
-    queueOrRun({
-      func: 'removeTrack',
-      args: [track._getMST()]
-    });
+  this.addTrack = function addTrack(track) {
+    internalMS.addTrack(track);
+  };
+
+  this.removeTrack = function removeTrack(track) {
+    internalMS.removeTrack(track);
   };
 
   // FIXME: implement clone

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -7,8 +7,8 @@ var _webrtc = require(binding_path);
 
 var EventTarget = require('./eventtarget');
 
-//var MediaStream               = require('./mediastream');
-//var MediaStreamEvent          = require('./mediastreamevent');
+var MediaStream               = require('./mediastream');
+var MediaStreamEvent          = require('./mediastreamevent');
 var RTCDataChannel            = require('./datachannel');
 var RTCDataChannelEvent       = require('./datachannelevent');
 var RTCError                  = require('./error');
@@ -300,11 +300,11 @@ function RTCPeerConnection(configuration, constraints) {
   };
 
   this.getLocalStreams = function getLocalStreams() {
-    return []; // pc.getLocalStreams();
+    return pc.getLocalStreams();
   };
 
   this.getRemoteStreams = function getRemoteStreams() {
-    return []; // pc.getRemoteStreams();
+    return pc.getRemoteStreams();
   };
 
   this.getStreamById = function getStreamById(streamId) {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -15,8 +15,8 @@ void init(v8::Handle<v8::Object> exports) {
   node_webrtc::DataChannel::Init(exports);
   MediaStream::Init(exports);
   MediaStreamTrack::Init(exports);
-  exports->Set( String::NewSymbol("getUserMedia"),
-    FunctionTemplate::New( GetUserMedia )->GetFunction() );
+  exports->Set( NanNew("getUserMedia"),
+    NanNew<v8::FunctionTemplate>( GetUserMedia )->GetFunction() );
 }
 
 NODE_MODULE(wrtc, init)

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -5,15 +5,18 @@
 
 #include "peerconnection.h"
 #include "datachannel.h"
-//#include "mediastream.h"
-//#include "mediastreamtrack.h"
+#include "mediastream.h"
+#include "mediastreamtrack.h"
+#include "getusermedia.h"
 
 void init(v8::Handle<v8::Object> exports) {
   talk_base::InitializeSSL();
   node_webrtc::PeerConnection::Init(exports);
   node_webrtc::DataChannel::Init(exports);
-  //MediaStream::Init(exports);
-  //MediaStreamTrack::Init(exports);
+  MediaStream::Init(exports);
+  MediaStreamTrack::Init(exports);
+  exports->Set( String::NewSymbol("getUserMedia"),
+    FunctionTemplate::New( GetUserMedia )->GetFunction() );
 }
 
 NODE_MODULE(wrtc, init)

--- a/src/getusermedia.cc
+++ b/src/getusermedia.cc
@@ -1,0 +1,48 @@
+#include <node.h>
+#include <v8.h>
+
+#include "talk/app/webrtc/peerconnectioninterface.h"
+
+#include "common.h"
+#include "mediastream.h"
+#include "nan.h"
+
+static const char *MEDIA_STREAM_NAME = "node-webrtc";
+static const char *AUDIO_TRACK_NAME = "node-webrtc-audio";
+
+static talk_base::scoped_refptr<webrtc::PeerConnectionFactoryInterface> peerConnectionFactory = webrtc::CreatePeerConnectionFactory();
+
+static talk_base::scoped_refptr<webrtc::MediaStreamInterface> getUserMedia(bool audio, bool video) {
+  talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream =
+    peerConnectionFactory->CreateLocalMediaStream(MEDIA_STREAM_NAME);
+  if (audio) {
+    talk_base::scoped_refptr<webrtc::AudioTrackInterface> audioTrack(
+      peerConnectionFactory->CreateAudioTrack(AUDIO_TRACK_NAME,
+        peerConnectionFactory->CreateAudioSource(NULL)));
+    stream->AddTrack(audioTrack);
+  }
+  if (video) {
+    // TODO(mroberts): Add video support.
+  }
+  return stream;
+}
+
+NAN_METHOD(GetUserMedia) {
+  TRACE_CALL;
+  NanScope();
+
+  v8::Local<v8::Object> options = v8::Local<v8::Object>::Cast(args[0]);
+  /*v8::Local<v8::Boolean> audio = options->Get(v8::String::NewSymbol("audio"))->ToBoolean();
+  v8::Local<v8::Boolean> video = options->Get(v8::String::NewSymbol("video"))->ToBoolean();*/
+
+  /*talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream = getUserMedia(audio->Value(), video->Value());*/
+  talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream = getUserMedia(true, false);
+
+  v8::Local<v8::Value> cargv[1];
+  cargv[0] = v8::External::New(static_cast<void*>(stream));
+
+  v8::Local<v8::Value> wrapped = NanNew(MediaStream::constructor)->NewInstance(1, cargv);
+
+  TRACE_END;
+  NanReturnValue(wrapped);
+}

--- a/src/getusermedia.cc
+++ b/src/getusermedia.cc
@@ -32,14 +32,14 @@ NAN_METHOD(GetUserMedia) {
   NanScope();
 
   v8::Local<v8::Object> options = v8::Local<v8::Object>::Cast(args[0]);
-  /*v8::Local<v8::Boolean> audio = options->Get(v8::String::NewSymbol("audio"))->ToBoolean();
-  v8::Local<v8::Boolean> video = options->Get(v8::String::NewSymbol("video"))->ToBoolean();*/
+  /*v8::Local<v8::Boolean> audio = options->Get(NanNew("audio"))->ToBoolean();
+  v8::Local<v8::Boolean> video = options->Get(NanNew("video"))->ToBoolean();*/
 
   /*talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream = getUserMedia(audio->Value(), video->Value());*/
   talk_base::scoped_refptr<webrtc::MediaStreamInterface> stream = getUserMedia(true, false);
 
   v8::Local<v8::Value> cargv[1];
-  cargv[0] = v8::External::New(static_cast<void*>(stream));
+  cargv[0] = NanNew<External>(static_cast<void*>(stream));
 
   v8::Local<v8::Value> wrapped = NanNew(MediaStream::constructor)->NewInstance(1, cargv);
 

--- a/src/getusermedia.h
+++ b/src/getusermedia.h
@@ -1,0 +1,8 @@
+#ifndef __GETUSERMEDIA_H__
+#define __GETUSERMEDIA_H__
+
+#include "nan.h"
+
+NAN_METHOD(GetUserMedia);
+
+#endif

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -21,7 +21,7 @@ MediaStream::MediaStream(webrtc::MediaStreamInterface* msi)
 {
   _inactive = !IsMediaStreamActive();
   uv_mutex_init(&lock);
-  uv_async_init(uv_default_loop(), &async, Run);
+  uv_async_init(uv_default_loop(), &async, reinterpret_cast<uv_async_cb>(Run));
 
   async.data = this;
 }
@@ -101,7 +101,7 @@ void MediaStream::Run(uv_async_t* handle, int status)
 
     if(MediaStream::ACTIVE & evt.type)
     {
-      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onactive")));
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(NanNew("onactive")));
       if(!callback.IsEmpty())
       {
         v8::Local<v8::Value> argv[0];
@@ -109,7 +109,7 @@ void MediaStream::Run(uv_async_t* handle, int status)
       }
     } else if(MediaStream::INACTIVE & evt.type)
     {
-      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("oninactive")));
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(NanNew("oninactive")));
       if(!callback.IsEmpty())
       {
         v8::Local<v8::Value> argv[0];
@@ -120,9 +120,9 @@ void MediaStream::Run(uv_async_t* handle, int status)
     {
       webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
-      cargv[0] = v8::External::New(static_cast<void*>(msti));
+      cargv[0] = NanNew<External>(static_cast<void*>(msti));
       v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
-      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onaddtrack")));
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(NanNew("onaddtrack")));
       if(!callback.IsEmpty())
       {
         v8::Local<v8::Value> argv[1];
@@ -134,9 +134,9 @@ void MediaStream::Run(uv_async_t* handle, int status)
     {
       webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
-      cargv[0] = v8::External::New(static_cast<void*>(msti));
+      cargv[0] = NanNew<External>(static_cast<void*>(msti));
       v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
-      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onremovetrack")));
+      v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(NanNew("onremovetrack")));
       if(!callback.IsEmpty())
       {
         v8::Local<v8::Value> argv[1];
@@ -145,7 +145,6 @@ void MediaStream::Run(uv_async_t* handle, int status)
       }
     }
   }
-  scope.Close(Undefined());
   TRACE_END;
 }
 
@@ -186,11 +185,11 @@ NAN_METHOD(MediaStream::getAudioTracks) {
   MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
   webrtc::AudioTrackVector audioTracks = self->_internalMediaStream->GetAudioTracks();
 
-  v8::Local<v8::Array> array = v8::Array::New(audioTracks.size());
+  v8::Local<v8::Array> array = NanNew<Array>(audioTracks.size());
   int index = 0;
   for (webrtc::AudioTrackVector::iterator track = audioTracks.begin(); track != audioTracks.end(); track++, index++) {
     v8::Local<v8::Value> cargv[1];
-    cargv[0] = v8::External::New(static_cast<void*>(track->get()));
+    cargv[0] = NanNew<External>(static_cast<void*>(track->get()));
     array->Set(index, NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv));
   }
 
@@ -205,11 +204,11 @@ NAN_METHOD(MediaStream::getVideoTracks) {
   MediaStream* self = ObjectWrap::Unwrap<MediaStream>( args.Holder() );
   webrtc::VideoTrackVector videoTracks = self->_internalMediaStream->GetVideoTracks();
 
-  v8::Local<v8::Array> array = v8::Array::New(videoTracks.size());
+  v8::Local<v8::Array> array = NanNew<Array>(videoTracks.size());
   int index = 0;
   for (webrtc::VideoTrackVector::iterator track = videoTracks.begin(); track != videoTracks.end(); track++, index++) {
     v8::Local<v8::Value> cargv[1];
-    cargv[0] = v8::External::New(static_cast<void*>(track->get()));
+    cargv[0] = NanNew<External>(static_cast<void*>(track->get()));
     array->Set(index, NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv));
   }
 
@@ -233,7 +232,7 @@ NAN_METHOD(MediaStream::getTrackById) {
   msti->AddRef();
 
   v8::Local<v8::Value> cargv[1];
-  cargv[0] = v8::External::New(static_cast<void*>(msti));
+  cargv[0] = NanNew<External>(static_cast<void*>(msti));
   v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
 
   TRACE_END;
@@ -254,7 +253,7 @@ NAN_METHOD(MediaStream::addTrack) {
   }
 
   TRACE_END;
-  NanReturnValue(Undefined());
+  NanReturnUndefined();
 }
 
 NAN_METHOD(MediaStream::removeTrack) {
@@ -271,7 +270,7 @@ NAN_METHOD(MediaStream::removeTrack) {
   }
 
   TRACE_END;
-  NanReturnValue(Undefined());
+  NanReturnUndefined();
 }
 
 NAN_METHOD(MediaStream::clone) {
@@ -279,7 +278,7 @@ NAN_METHOD(MediaStream::clone) {
   NanScope();
 
   TRACE_END;
-  NanReturnValue(Undefined());
+  NanReturnUndefined();
 }
 
 NAN_GETTER(MediaStream::GetId) {
@@ -291,7 +290,7 @@ NAN_GETTER(MediaStream::GetId) {
   std::string label = self->_internalMediaStream->label();
 
   TRACE_END;
-  NanReturnValue(String::New(label.c_str()));
+  NanReturnValue(NanNew(label.c_str()));
 }
 
 NAN_GETTER(MediaStream::IsInactive) {
@@ -302,7 +301,7 @@ NAN_GETTER(MediaStream::IsInactive) {
   bool inactive = self->_inactive;
 
   TRACE_END;
-  NanReturnValue(Boolean::New(inactive));
+  NanReturnValue(NanNew<Boolean>(inactive));
 }
 
 NAN_SETTER(MediaStream::ReadOnly) {
@@ -311,27 +310,27 @@ NAN_SETTER(MediaStream::ReadOnly) {
 
 
 void MediaStream::Init( Handle<Object> exports ) {
-  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
-  tpl->SetClassName( String::NewSymbol( "MediaStream" ) );
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>( New );
+  tpl->SetClassName( NanNew( "MediaStream" ) );
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getAudioTracks" ),
-    FunctionTemplate::New( getAudioTracks )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getVideoTracks" ),
-    FunctionTemplate::New( getVideoTracks )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getTrackById" ),
-    FunctionTemplate::New( getTrackById )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getAudioTracks" ),
+    NanNew<FunctionTemplate>( getAudioTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getVideoTracks" ),
+    NanNew<FunctionTemplate>( getVideoTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getTrackById" ),
+    NanNew<FunctionTemplate>( getTrackById )->GetFunction() );
 
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "addTrack" ),
-    FunctionTemplate::New( addTrack )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "removeTrack" ),
-    FunctionTemplate::New( removeTrack )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "addTrack" ),
+    NanNew<FunctionTemplate>( addTrack )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "removeTrack" ),
+    NanNew<FunctionTemplate>( removeTrack )->GetFunction() );
 
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "clone" ),
-    FunctionTemplate::New( clone )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "clone" ),
+    NanNew<FunctionTemplate>( clone )->GetFunction() );
 
-  tpl->InstanceTemplate()->SetAccessor(String::New("id"), GetId, ReadOnly);
-  tpl->InstanceTemplate()->SetAccessor(String::New("inactive"), IsInactive, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(NanNew("id"), GetId, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(NanNew("inactive"), IsInactive, ReadOnly);
 
   NanAssignPersistent(constructor, tpl->GetFunction());
-  exports->Set( String::NewSymbol("MediaStream"), tpl->GetFunction() );
+  exports->Set( NanNew("MediaStream"), tpl->GetFunction() );
 }

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -22,7 +22,7 @@ MediaStreamTrack::MediaStreamTrack(webrtc::MediaStreamTrackInterface* msti)
   _muted = false;
   _live = _internalMediaStreamTrack->state() == webrtc::MediaStreamTrackInterface::kLive;
   uv_mutex_init(&lock);
-  uv_async_init(uv_default_loop(), &async, Run);
+  uv_async_init(uv_default_loop(), &async, reinterpret_cast<uv_async_cb>(Run));
 
   async.data = this;
 }
@@ -136,7 +136,6 @@ void MediaStreamTrack::Run(uv_async_t* handle, int status)
     }
 
   }
-  scope.Close(Undefined());
   TRACE_END;
 }
 
@@ -156,7 +155,7 @@ NAN_METHOD(MediaStreamTrack::clone) {
   NanScope();
   // todo: implement
   TRACE_END;
-  NanReturnValue(Undefined());
+  NanReturnUndefined();
 }
 
 NAN_METHOD(MediaStreamTrack::stop) {
@@ -164,7 +163,7 @@ NAN_METHOD(MediaStreamTrack::stop) {
   NanScope();
   // todo: implement
   TRACE_END;
-  NanReturnValue(Undefined());
+  NanReturnUndefined();
 }
 
 NAN_GETTER(MediaStreamTrack::GetId) {
@@ -208,28 +207,28 @@ NAN_GETTER(MediaStreamTrack::GetEnabled) {
   bool enabled = self->_internalMediaStreamTrack->enabled();
 
   TRACE_END;
-  NanReturnValue(Boolean::New(enabled));
+  NanReturnValue(NanNew<Boolean>(enabled));
 }
 
 NAN_GETTER(MediaStreamTrack::GetMuted) {
   TRACE_CALL;
   NanScope();
   TRACE_END;
-  NanReturnValue(Boolean::New(false));
+  NanReturnValue(NanNew<Boolean>(false));
 }
 
 NAN_GETTER(MediaStreamTrack::GetReadOnly) {
   TRACE_CALL;
   NanScope();
   TRACE_END;
-  NanReturnValue(Boolean::New(false));
+  NanReturnValue(NanNew<Boolean>(false));
 }
 
 NAN_GETTER(MediaStreamTrack::GetRemote) {
   TRACE_CALL;
   NanScope();
   TRACE_END;
-  NanReturnValue(Boolean::New(false));
+  NanReturnValue(NanNew<Boolean>(false));
 }
 
 NAN_GETTER(MediaStreamTrack::GetReadyState) {
@@ -241,7 +240,7 @@ NAN_GETTER(MediaStreamTrack::GetReadyState) {
   webrtc::MediaStreamTrackInterface::TrackState state = self->_internalMediaStreamTrack->state();
 
   TRACE_END;
-  NanReturnValue(Number::New(static_cast<uint32_t>(state)));
+  NanReturnValue(NanNew<Number>(static_cast<uint32_t>(state)));
 }
 
 NAN_SETTER(MediaStreamTrack::SetEnabled) {
@@ -259,14 +258,14 @@ NAN_SETTER(MediaStreamTrack::ReadOnly) {
 }
 
 void MediaStreamTrack::Init( Handle<Object> exports ) {
-  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>( New );
   tpl->SetClassName( NanNew( "MediaStreamTrack" ) );
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   tpl->PrototypeTemplate()->Set( NanNew( "clone" ),
-    FunctionTemplate::New( clone )->GetFunction() );
+    NanNew<FunctionTemplate>( clone )->GetFunction() );
   tpl->PrototypeTemplate()->Set( NanNew( "stop" ),
-    FunctionTemplate::New( stop )->GetFunction() );
+    NanNew<FunctionTemplate>( stop )->GetFunction() );
 
   tpl->InstanceTemplate()->SetAccessor(NanNew("id"), GetId, ReadOnly);
   tpl->InstanceTemplate()->SetAccessor(NanNew("kind"), GetKind, ReadOnly);

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -277,6 +277,6 @@ void MediaStreamTrack::Init( Handle<Object> exports ) {
   tpl->InstanceTemplate()->SetAccessor(NanNew("remote"), GetRemote, ReadOnly);
   tpl->InstanceTemplate()->SetAccessor(NanNew("readyState"), GetReadyState, ReadOnly);
 
-  NanAssignPersistent(Function, constructor, tpl->GetFunction());
+  NanAssignPersistent(constructor, tpl->GetFunction());
   exports->Set( NanNew("MediaStreamTrack"), tpl->GetFunction() );
 }

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -16,7 +16,7 @@
 #include "common.h"
 #include "peerconnection.h"
 #include "datachannel.h"
-//#include "mediastream.h"
+#include "mediastream.h"
 #include "create-offer-observer.h"
 #include "create-answer-observer.h"
 #include "set-local-description-observer.h"
@@ -179,7 +179,7 @@ void PeerConnection::Run(uv_async_t* handle, int status)
       v8::Local<v8::Value> argv[1];
       argv[0] = dc;
       NanMakeCallback(pc, callback, 1, argv);
-    }/* else if(PeerConnection::NOTIFY_ADD_STREAM & evt.type)
+    } else if(PeerConnection::NOTIFY_ADD_STREAM & evt.type)
     {
       webrtc::MediaStreamInterface* msi = static_cast<webrtc::MediaStreamInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
@@ -207,7 +207,7 @@ void PeerConnection::Run(uv_async_t* handle, int status)
         argv[0] = ms;
         NanMakeCallback(pc, callback, 1, argv);
       }
-    }*/
+    }
   }
 
   if(do_shutdown) {
@@ -245,19 +245,15 @@ void PeerConnection::OnIceGatheringChange( webrtc::PeerConnectionInterface::IceG
 
 void PeerConnection::OnAddStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  /*
   media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_ADD_STREAM, static_cast<void*>(media_stream));
-  */
   TRACE_END;
 }
 
 void PeerConnection::OnRemoveStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  /*
   media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_REMOVE_STREAM, static_cast<void*>(media_stream));
-  */
   TRACE_END;
 }
 
@@ -444,7 +440,6 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   NanReturnValue(dc);
 }
 
-/*
 NAN_METHOD(PeerConnection::AddStream) {
   TRACE_CALL;
   NanScope();
@@ -532,7 +527,7 @@ NAN_METHOD(PeerConnection::GetStreamById) {
     NanReturnValue(NanUndefined());
   }
 }
-*/
+
 NAN_METHOD(PeerConnection::UpdateIce) {
   TRACE_CALL;
   NanScope();
@@ -656,7 +651,7 @@ void PeerConnection::Init( Handle<Object> exports ) {
 
   tpl->PrototypeTemplate()->Set( NanNew( "createDataChannel" ),
     NanNew<FunctionTemplate>( CreateDataChannel )->GetFunction() );
-/*
+
   tpl->PrototypeTemplate()->Set( NanNew( "getLocalStreams" ),
     NanNew<FunctionTemplate>( GetLocalStreams )->GetFunction() );
 
@@ -671,7 +666,7 @@ void PeerConnection::Init( Handle<Object> exports ) {
 
   tpl->PrototypeTemplate()->Set( NanNew( "removeStream" ),
     NanNew<FunctionTemplate>( RemoveStream )->GetFunction() );
-*/
+
   tpl->PrototypeTemplate()->Set( NanNew( "close" ),
     NanNew<FunctionTemplate>( Close )->GetFunction() );
 

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -149,13 +149,11 @@ public:
   static NAN_METHOD(UpdateIce);
   static NAN_METHOD(AddIceCandidate);
   static NAN_METHOD(CreateDataChannel);
-  /*
   static NAN_METHOD(GetLocalStreams);
   static NAN_METHOD(GetRemoteStreams);
   static NAN_METHOD(GetStreamById);
   static NAN_METHOD(AddStream);
   static NAN_METHOD(RemoveStream);
-  */
   static NAN_METHOD(Close);
 
   static NAN_GETTER(GetLocalDescription);


### PR DESCRIPTION
This pull request adds initial `getUserMedia` support to node-webrtc. `getUserMedia` has been discussed a little bit (e.g. #25, #43), and I'd like to see it added. For one, it would allow WebRTC clients to move more of their tests out of the browser and into the command-line.

You can use it like

``` js
if (detected === NODE) {
  var wrtc = require('wrtc');
  RTCPeerConnection = wrtc.RTCPeerConnection;
  RTCSessionDescription = wrtc.RTCSessionDescription;
  RTCIceCandidate = wrtc.RTCIceCandidate;
  getUserMedia = wrtc.getUserMedia;
} else if (detected === CHROME) {
  RTCPeerConnection = window.webkitRTCPeerConnection;
  getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
}
```

I tested by making a call between Node.js and Chrome. [See here.](https://gist.github.com/markandrus/c1dad8607de5b7713214)

I'm not sure about functions `runImmediately`, `queueOrRun`, or `_executeNext` in `mediastream.js`, though.
