### PR TITLE
MediaStreams

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Alex Londeree <alex.londeree@gmail.com>
 Jesús Leganés Combarro "piranna" <piranna@gmail.com>
 Dario Andrei <wouldgo84@gmail.com>
 Matt Porritt <mattp@catalyst-au.net>
+Blake La Pierre <blakelapierre@gmail.com>

--- a/binding.gyp
+++ b/binding.gyp
@@ -235,8 +235,8 @@
         'src/set-remote-description-observer.cc',
         'src/peerconnection.cc',
         'src/datachannel.cc',
-#        'src/mediastream.cc',
-#        'src/mediastreamtrack.cc',
+        'src/mediastream.cc',
+        'src/mediastreamtrack.cc'
       ]
     },
     {

--- a/examples/streamtest/index.html
+++ b/examples/streamtest/index.html
@@ -1,5 +1,8 @@
 <html>
-<body></body>
+<body>
+  <video id="source" autoplay></video>
+  <video id="rebroadcast" autoplay></video>
+</body>
 <script src="/socket.io/socket.io.js"></script>
 
 <script src="../../dist/wrtc.js"></script>

--- a/examples/streamtest/peerstream.js
+++ b/examples/streamtest/peerstream.js
@@ -11,25 +11,27 @@ if (!navigator.getMedia)
     console.log('Error: getUserMedia is not supported on this browser');
 else {
     var socket = io.connect();
-    
+
     socket.on('connected', function(){
         navigator.getMedia({video:true,audio:true}, function (source) {
             console.log('local stream created');
             media = source;
+            var sourceEl = document.getElementById('source');
+            sourceEl.src = window.URL.createObjectURL(media);
             start();
         }, logError);
     });
-    
+
     socket.on('logmessage',function(message){
         logMessage(message);
     });
-    
+
     socket.on('message',function(data){
         logMessage('message received');
         if (!pc) {
             start();
         }
-        
+
         var message = JSON.parse(data);
         if (message.sdp) {
             pc.setRemoteDescription(new RTCSessionDescription(message.sdp), function () {
@@ -42,46 +44,48 @@ else {
             pc.addIceCandidate(new RTCIceCandidate(message.candidate));
         }
     });
-    
+
     var isHost = true;
     var media  = null;
-    
+
     var pc = null;
     var configuration = { "iceServers": [{ "url": "stun:stun.example.org" }] };
-    
+
     var logMessage = function (message) {
         console.log(message);
     };
-    
+
     var logError = function (error) {
         throw error;
     };
-        
+
     var localDescCreated = function (desc) {
         pc.setLocalDescription(desc, function () {
             socket.emit('message', JSON.stringify({ "sdp": pc.localDescription }));
         }, logError);
     };
-    
+
     var start = function () {
         logMessage('rtc peer connection object initializing');
         pc = new RTCPeerConnection(configuration);
-    
+
         pc.onicecandidate = function (evt) {
             if (evt.candidate) {
                 console.log('ice candidate sent');
                 socket.emit('message', JSON.stringify({ "candidate": evt.candidate }));
             }
         };
-    
+
         pc.onnegotiationneeded = function () {
             pc.createOffer(localDescCreated, logError);
         };
-    
+
         pc.onaddstream = function (evt) {
             logMessage('rtc remote stream added successfully');
+            var rebroadcast = document.getElementById('rebroadcast');
+            rebroadcast.src = window.URL.createObjectURL(evt.stream);
         };
-        
+
         if (isHost) {
             console.log('local stream added to rtc connection for broadcast');
             pc.addStream(media);

--- a/examples/streamtest/webbridge.js
+++ b/examples/streamtest/webbridge.js
@@ -15,56 +15,60 @@ router.use('/', express.static(__dirname + '/.'));
 var config1 = { iceServers: [{url:'stun:stun.l.google.com:19302'}] };
 var config2 = { 'optional': [{DtlsSrtpKeyAgreement: false}] };
 
-io.set('transports',['xhr-polling']);
+//io.set('transports',['xhr-polling']);
 
 io.on('connection', function (socket) {
     socket.emit('connected');
-    
+
     var pc = null;
     //var isHost = false;
-    
+
     function logMessage(message) {
         console.log(message);
         message = 'server: ' + message;
         socket.emit('logmessage',message);
     }
-    
+
     logMessage('client connected');
-    
+
     function logError(error) {
         logMessage("Error: " + error);
         throw error;
     }
-    
+
     function start() {
         logMessage('rtc peer connection object initializing');
         pc = new webrtc.RTCPeerConnection(config1,config2);
-    
+
         pc.onicecandidate = function (evt) {
             if (evt.candidate) {
                 logMessage('ice candidate found');
                 socket.emit('message', JSON.stringify({ "candidate": evt.candidate }));
             }
         };
-    
+
         pc.onnegotiationneeded = function () {
             logMessage('creating offer');
             pc.createOffer(localDescCreated, logError);
         };
-    
+
         pc.onaddstream = function (evt) {
             logMessage('rtc remote stream added successfully');
             console.log(evt);
             pc.addStream(evt);
         };
-        
+
+        pc.oniceconnectionstatechange = function (evt) {
+            console.log('ICE:', pc.iceConnectionState);
+        };
+
         /*if (isHost) {
             console.log('local stream added to rtc connection for broadcast');
             pc.addStream(media);
         }*/
         logMessage('rtc peer connection created');
     }
-        
+
     function localDescCreated(desc) {
         logMessage('setting local description');
         pc.setLocalDescription(desc, function () {
@@ -77,7 +81,7 @@ io.on('connection', function (socket) {
         if (!pc) {
             start();
         }
-        
+
         var message = JSON.parse(data);
         if (message.sdp) {
             logMessage('sdp message: setting remote description');

--- a/examples/streamtest/webbridge.js
+++ b/examples/streamtest/webbridge.js
@@ -73,7 +73,13 @@ io.on('connection', function (socket) {
         };
 
         pc.oniceconnectionstatechange = function (evt) {
-            console.log('ICE:', pc.iceConnectionState);
+            if (pc.iceConnectionState === 'disconnected') {
+                console.log('client disconnected');
+                pc.close();
+            }
+            else if (pc.iceConnectionState === 'closed') {
+                pc = null;
+            }
         };
 
         /*if (isHost) {

--- a/lib/mediastream.js
+++ b/lib/mediastream.js
@@ -4,13 +4,6 @@ var MediaStreamTrackEvent = require('./mediastreamtrackevent');
 var MediaStreamTrack      = require('./mediastreamtrack');
 
 
-//MediaStream.prototype._getMS = function _getMS() {
-//  if(!this._ms) {
-//    throw new Error('RTCMediaSteam is gone');
-//  }
-//  return this._ms;
-//};
-
 //MediaStream.prototype._executeNext = function _executeNext() {
 //  var obj, ms;
 //  ms = this._getMS();
@@ -36,6 +29,8 @@ function MediaStream(internalMS) {
     , pending = null;
 
   EventTarget.call(this);
+
+  this._ms = internalMS;
 
 //  internalMS.onactive = function onactive() {
 //    that.dispatchEvent({type: 'active'});
@@ -71,6 +66,10 @@ function MediaStream(internalMS) {
     }
   }
 
+  function runImmediately(obj) {
+    return internalMS[obj.func].apply(internalMS, obj.args);
+  }
+
   Object.defineProperties(this, {
     'id': {
       get: function getId() {
@@ -90,35 +89,35 @@ function MediaStream(internalMS) {
     }
   });
 
-  this.getaudiotracks = function getaudiotracks() {
+  this.getAudioTracks = function getaudiotracks() {
     return runImmediately({
       func: 'getAudioTracks',
       args: []
     });
   };
 
-  this.getvideotracks = function getvideotracks() {
+  this.getVideoTracks = function getvideotracks() {
     return runImmediately({
       func: 'getVideoTracks',
       args: []
     });
   };
 
-  this.gettrackbyid = function gettrackbyid(id) {
+  this.getTrackById = function gettrackbyid(id) {
     return runImmediately({
       func: 'getTrackById',
       args: [id]
     });
   };
 
-  this.addtrack = function addtrack(track) {
+  this.addTrack = function addtrack(track) {
     queueOrRun({
       func: 'addTrack',
       args: [track._getMST()]
     });
   };
 
-  this.removetrack = function removetrack(track) {
+  this.removeTrack = function removetrack(track) {
     queueOrRun({
       func: 'removeTrack',
       args: [track._getMST()]
@@ -130,5 +129,14 @@ function MediaStream(internalMS) {
     return internalMS.clone();
   };*/
 }
+
+MediaStream.prototype._getMS = function _getMS() {
+  'use strict';
+
+  if(!this._ms) {
+    throw new Error('RTCMediaSteam is gone');
+  }
+  return this._ms;
+};
 
 module.exports = MediaStream;

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -7,8 +7,8 @@ var _webrtc = require(binding_path);
 
 var EventTarget = require('./eventtarget');
 
-//var MediaStream               = require('./mediastream');
-//var MediaStreamEvent          = require('./mediastreamevent');
+var MediaStream               = require('./mediastream');
+var MediaStreamEvent          = require('./mediastreamevent');
 var RTCDataChannel            = require('./datachannel');
 var RTCDataChannelEvent       = require('./datachannelevent');
 var RTCError                  = require('./error');

--- a/package.json
+++ b/package.json
@@ -28,15 +28,17 @@
     "nopt": "^2.2.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.0.0-rc13",
+    "express": "^4.8.5",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-tape": "~0.0.2",
-    "tape": "~2.4.2",
-    "ws": "~0.4.31",
-    "aws-sdk": "^2.0.0-rc13",
-    "node-static": "^0.7.3",
     "minimist": "0.0.8",
-    "node-static-alias": "^0.1.0"
+    "node-static": "^0.7.3",
+    "node-static-alias": "^0.1.0",
+    "socket.io": "^1.0.6",
+    "tape": "~2.4.2",
+    "ws": "~0.4.31"
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -5,15 +5,15 @@
 
 #include "peerconnection.h"
 #include "datachannel.h"
-//#include "mediastream.h"
-//#include "mediastreamtrack.h"
+#include "mediastream.h"
+#include "mediastreamtrack.h"
 
 void init(v8::Handle<v8::Object> exports) {
   talk_base::InitializeSSL();
   node_webrtc::PeerConnection::Init(exports);
   node_webrtc::DataChannel::Init(exports);
-  //MediaStream::Init(exports);
-  //MediaStreamTrack::Init(exports);
+  MediaStream::Init(exports);
+  MediaStreamTrack::Init(exports);
 }
 
 NODE_MODULE(wrtc, init)

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -122,7 +122,7 @@ void MediaStream::Run(uv_async_t* handle, int status)
       webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
       cargv[0] = v8::External::New(static_cast<void*>(msti));
-      v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+      v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onaddtrack")));
       if(!callback.IsEmpty())
       {
@@ -136,7 +136,7 @@ void MediaStream::Run(uv_async_t* handle, int status)
       webrtc::MediaStreamTrackInterface* msti = static_cast<webrtc::MediaStreamTrackInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
       cargv[0] = v8::External::New(static_cast<void*>(msti));
-      v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+      v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(ms->Get(String::New("onremovetrack")));
       if(!callback.IsEmpty())
       {
@@ -192,7 +192,7 @@ NAN_METHOD(MediaStream::getAudioTracks) {
   for (webrtc::AudioTrackVector::iterator track = audioTracks.begin(); track != audioTracks.end(); track++, index++) {
     v8::Local<v8::Value> cargv[1];
     cargv[0] = v8::External::New(static_cast<void*>(track->get()));
-    array->Set(index, NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv));
+    array->Set(index, NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv));
   }
 
   TRACE_END;
@@ -211,7 +211,7 @@ NAN_METHOD(MediaStream::getVideoTracks) {
   for (webrtc::VideoTrackVector::iterator track = videoTracks.begin(); track != videoTracks.end(); track++, index++) {
     v8::Local<v8::Value> cargv[1];
     cargv[0] = v8::External::New(static_cast<void*>(track->get()));
-    array->Set(index, NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv));
+    array->Set(index, NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv));
   }
 
   TRACE_END;
@@ -235,7 +235,7 @@ NAN_METHOD(MediaStream::getTrackById) {
 
   v8::Local<v8::Value> cargv[1];
   cargv[0] = v8::External::New(static_cast<void*>(msti));
-  v8::Local<v8::Value> mst = NanPersistentToLocal(MediaStreamTrack::constructor)->NewInstance(1, cargv);
+  v8::Local<v8::Value> mst = NanNew(MediaStreamTrack::constructor)->NewInstance(1, cargv);
 
   TRACE_END;
   NanReturnValue(mst);
@@ -312,27 +312,27 @@ NAN_SETTER(MediaStream::ReadOnly) {
 
 
 void MediaStream::Init( Handle<Object> exports ) {
-  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
-  tpl->SetClassName( String::NewSymbol( "MediaStream" ) );
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>( New );
+  tpl->SetClassName( NanNew( "MediaStream" ) );
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getaudiotracks" ),
-    FunctionTemplate::New( getAudioTracks )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "getvideotracks" ),
-    FunctionTemplate::New( getVideoTracks )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "gettrackbyid" ),
-    FunctionTemplate::New( getTrackById )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getAudioTracks" ),
+    NanNew<FunctionTemplate>( getAudioTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getVideoTracks" ),
+    NanNew<FunctionTemplate>( getVideoTracks )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "getTrackById" ),
+    NanNew<FunctionTemplate>( getTrackById )->GetFunction() );
 
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "addtrack" ),
-    FunctionTemplate::New( addTrack )->GetFunction() );
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "removetrack" ),
-    FunctionTemplate::New( removeTrack )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "addTrack" ),
+    NanNew<FunctionTemplate>( addTrack )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "removeTrack" ),
+    NanNew<FunctionTemplate>( removeTrack )->GetFunction() );
 
-  tpl->PrototypeTemplate()->Set( String::NewSymbol( "clone" ),
-    FunctionTemplate::New( clone )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "clone" ),
+    NanNew<FunctionTemplate>( clone )->GetFunction() );
 
-  tpl->InstanceTemplate()->SetAccessor(String::New("id"), GetId, ReadOnly);
-  tpl->InstanceTemplate()->SetAccessor(String::New("inactive"), IsInactive, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(NanNew("id"), GetId, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(NanNew("inactive"), IsInactive, ReadOnly);
 
-  NanAssignPersistent(Function, constructor, tpl->GetFunction());
-  exports->Set( String::NewSymbol("MediaStream"), tpl->GetFunction() );
+  NanAssignPersistent(constructor, tpl->GetFunction());
+  exports->Set( NanNew("MediaStream"), constructor );
 }

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -18,7 +18,7 @@ Persistent<Function> MediaStreamTrack::constructor;
 MediaStreamTrack::MediaStreamTrack(webrtc::MediaStreamTrackInterface* msti)
 : _internalMediaStreamTrack(msti)
 {
-  msti->Release();
+  msti->AddRef();
   _muted = false;
   _live = _internalMediaStreamTrack->state() == webrtc::MediaStreamTrackInterface::kLive;
   uv_mutex_init(&lock);
@@ -29,7 +29,7 @@ MediaStreamTrack::MediaStreamTrack(webrtc::MediaStreamTrackInterface* msti)
 
 MediaStreamTrack::~MediaStreamTrack()
 {
-
+  _internalMediaStreamTrack->Release();
 }
 
 NAN_METHOD(MediaStreamTrack::New) {
@@ -102,7 +102,7 @@ void MediaStreamTrack::Run(uv_async_t* handle, int status)
     if(MediaStreamTrack::MUTE & evt.type)
     {
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(NanNew("onmute")));
-      if(!callback.IsEmpty())
+      if(!callback->IsUndefined())
       {
         v8::Local<v8::Value> argv[0];
         NanMakeCallback(mst, callback, 0, argv);
@@ -110,7 +110,7 @@ void MediaStreamTrack::Run(uv_async_t* handle, int status)
     } else if(MediaStreamTrack::UNMUTE & evt.type)
     {
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(NanNew("onunmute")));
-      if(!callback.IsEmpty())
+      if(!callback->IsUndefined())
       {
         v8::Local<v8::Value> argv[0];
         NanMakeCallback(mst, callback, 0, argv);
@@ -119,7 +119,7 @@ void MediaStreamTrack::Run(uv_async_t* handle, int status)
     if(MediaStreamTrack::STARTED & evt.type)
     {
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(NanNew("onstarted")));
-      if(!callback.IsEmpty())
+      if(!callback->IsUndefined())
       {
         v8::Local<v8::Value> argv[0];
         NanMakeCallback(mst, callback, 0, argv);
@@ -128,7 +128,7 @@ void MediaStreamTrack::Run(uv_async_t* handle, int status)
     if(MediaStreamTrack::ENDED & evt.type)
     {
       v8::Local<v8::Function> callback = v8::Local<v8::Function>::Cast(mst->Get(NanNew("onended")));
-      if(!callback.IsEmpty())
+      if(!callback->IsUndefined())
       {
         v8::Local<v8::Value> argv[0];
         NanMakeCallback(mst, callback, 0, argv);

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -259,14 +259,14 @@ NAN_SETTER(MediaStreamTrack::ReadOnly) {
 }
 
 void MediaStreamTrack::Init( Handle<Object> exports ) {
-  Local<FunctionTemplate> tpl = FunctionTemplate::New( New );
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>( New );
   tpl->SetClassName( NanNew( "MediaStreamTrack" ) );
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   tpl->PrototypeTemplate()->Set( NanNew( "clone" ),
-    FunctionTemplate::New( clone )->GetFunction() );
+    NanNew<FunctionTemplate>( clone )->GetFunction() );
   tpl->PrototypeTemplate()->Set( NanNew( "stop" ),
-    FunctionTemplate::New( stop )->GetFunction() );
+    NanNew<FunctionTemplate>( stop )->GetFunction() );
 
   tpl->InstanceTemplate()->SetAccessor(NanNew("id"), GetId, ReadOnly);
   tpl->InstanceTemplate()->SetAccessor(NanNew("kind"), GetKind, ReadOnly);
@@ -277,6 +277,6 @@ void MediaStreamTrack::Init( Handle<Object> exports ) {
   tpl->InstanceTemplate()->SetAccessor(NanNew("remote"), GetRemote, ReadOnly);
   tpl->InstanceTemplate()->SetAccessor(NanNew("readyState"), GetReadyState, ReadOnly);
 
-  NanAssignPersistent(Function, constructor, tpl->GetFunction());
+  NanAssignPersistent(constructor, tpl->GetFunction());
   exports->Set( NanNew("MediaStreamTrack"), tpl->GetFunction() );
 }

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -16,7 +16,7 @@
 #include "common.h"
 #include "peerconnection.h"
 #include "datachannel.h"
-//#include "mediastream.h"
+#include "mediastream.h"
 #include "create-offer-observer.h"
 #include "create-answer-observer.h"
 #include "set-local-description-observer.h"
@@ -179,7 +179,7 @@ void PeerConnection::Run(uv_async_t* handle, int status)
       v8::Local<v8::Value> argv[1];
       argv[0] = dc;
       NanMakeCallback(pc, callback, 1, argv);
-    }/* else if(PeerConnection::NOTIFY_ADD_STREAM & evt.type)
+    } else if(PeerConnection::NOTIFY_ADD_STREAM & evt.type)
     {
       webrtc::MediaStreamInterface* msi = static_cast<webrtc::MediaStreamInterface*>(evt.data);
       v8::Local<v8::Value> cargv[1];
@@ -207,7 +207,7 @@ void PeerConnection::Run(uv_async_t* handle, int status)
         argv[0] = ms;
         NanMakeCallback(pc, callback, 1, argv);
       }
-    }*/
+    }
   }
 
   if(do_shutdown) {
@@ -245,19 +245,15 @@ void PeerConnection::OnIceGatheringChange( webrtc::PeerConnectionInterface::IceG
 
 void PeerConnection::OnAddStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  /*
   media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_ADD_STREAM, static_cast<void*>(media_stream));
-  */
   TRACE_END;
 }
 
 void PeerConnection::OnRemoveStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  /*
   media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_REMOVE_STREAM, static_cast<void*>(media_stream));
-  */
   TRACE_END;
 }
 
@@ -444,7 +440,6 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   NanReturnValue(dc);
 }
 
-/*
 NAN_METHOD(PeerConnection::AddStream) {
   TRACE_CALL;
   NanScope();
@@ -532,7 +527,7 @@ NAN_METHOD(PeerConnection::GetStreamById) {
     NanReturnValue(NanUndefined());
   }
 }
-*/
+
 NAN_METHOD(PeerConnection::UpdateIce) {
   TRACE_CALL;
   NanScope();
@@ -656,7 +651,7 @@ void PeerConnection::Init( Handle<Object> exports ) {
 
   tpl->PrototypeTemplate()->Set( NanNew( "createDataChannel" ),
     NanNew<FunctionTemplate>( CreateDataChannel )->GetFunction() );
-/*
+
   tpl->PrototypeTemplate()->Set( NanNew( "getLocalStreams" ),
     NanNew<FunctionTemplate>( GetLocalStreams )->GetFunction() );
 
@@ -671,7 +666,7 @@ void PeerConnection::Init( Handle<Object> exports ) {
 
   tpl->PrototypeTemplate()->Set( NanNew( "removeStream" ),
     NanNew<FunctionTemplate>( RemoveStream )->GetFunction() );
-*/
+
   tpl->PrototypeTemplate()->Set( NanNew( "close" ),
     NanNew<FunctionTemplate>( Close )->GetFunction() );
 

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -245,14 +245,12 @@ void PeerConnection::OnIceGatheringChange( webrtc::PeerConnectionInterface::IceG
 
 void PeerConnection::OnAddStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_ADD_STREAM, static_cast<void*>(media_stream));
   TRACE_END;
 }
 
 void PeerConnection::OnRemoveStream( webrtc::MediaStreamInterface* media_stream ) {
   TRACE_CALL;
-  media_stream->AddRef();
   QueueEvent(PeerConnection::NOTIFY_REMOVE_STREAM, static_cast<void*>(media_stream));
   TRACE_END;
 }

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -149,13 +149,13 @@ public:
   static NAN_METHOD(UpdateIce);
   static NAN_METHOD(AddIceCandidate);
   static NAN_METHOD(CreateDataChannel);
-  /*
+
   static NAN_METHOD(GetLocalStreams);
   static NAN_METHOD(GetRemoteStreams);
   static NAN_METHOD(GetStreamById);
   static NAN_METHOD(AddStream);
   static NAN_METHOD(RemoveStream);
-  */
+
   static NAN_METHOD(Close);
 
   static NAN_GETTER(GetLocalDescription);


### PR DESCRIPTION
This gets the streamtest example working. The example shows forwarding MediaStreams for relay/broadcast scenarios.

Mostly I uncommented the MediaStream code that was already in there. I had to make some changes to get it to compile.

I also updated the example to show the original stream that is being sent and the stream that is being rebroadcast.

Enabling TRACING/debug shows that some things may not be cleaned up when a PeerConnection terminates.

Note: There are currently issues with libwebrtc preventing audio tracks from being properly forwarded. It might be possible to hack in a patch to get it working in this case, but according to the webrtc tracker it may be more difficult: https://code.google.com/p/webrtc/issues/detail?id=2192

Sorry for the double pull request. I had rebased my branch to the latest develop and it made the history a little strange. This should be a cleaner request.
