### PR TITLE
Add getStats support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Alex Londeree <alex.londeree@gmail.com>
 Jesús Leganés Combarro "piranna" <piranna@gmail.com>
 Dario Andrei <wouldgo84@gmail.com>
 Matt Porritt <mattp@catalyst-au.net>
+Mark Andrus Roberts <markandrusroberts@gmail.com>

--- a/binding.gyp
+++ b/binding.gyp
@@ -136,6 +136,9 @@
         'src/set-remote-description-observer.cc',
         'src/peerconnection.cc',
         'src/datachannel.cc',
+        'src/rtcstatsreport.cc',
+        'src/rtcstatsresponse.cc',
+        'src/stats-observer.cc'
       ]
     }
   ]

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -13,6 +13,7 @@ var RTCError                  = require('./error');
 var RTCIceCandidate           = require('./icecandidate');
 var RTCPeerConnectionIceEvent = require('./rtcpeerconnectioniceevent');
 var RTCSessionDescription     = require('./sessiondescription');
+var RTCStatsResponse          = require('./rtcstatsresponse');
 
 function RTCPeerConnection(configuration, constraints) {
   'use strict';
@@ -303,6 +304,12 @@ function RTCPeerConnection(configuration, constraints) {
 
   this.getRemoteStreams = function getRemoteStreams() {
     return []; // pc.getRemoteStreams();
+  };
+
+  this.getStats = function getStats(onSuccess, onFailure) {
+    pc.getStats(function(internalRTCStatsResponse) {
+      onSuccess(new RTCStatsResponse(internalRTCStatsResponse));
+    }, onFailure);
   };
 
   this.getStreamById = function getStreamById(streamId) {

--- a/lib/rtcstatsreport.js
+++ b/lib/rtcstatsreport.js
@@ -1,0 +1,22 @@
+function RTCStatsReport(internalRTCStatsReport) {
+  'use strict';
+
+  Object.defineProperties(this, {
+    'timestamp': {
+      value: internalRTCStatsReport.timestamp
+    },
+    'type': {
+      value: internalRTCStatsReport.type
+    }
+  });
+
+  this.names = function names() {
+    return internalRTCStatsReport.names();
+  };
+
+  this.stat = function stat(name) {
+    return internalRTCStatsReport.stat(name);
+  };
+}
+
+module.exports = RTCStatsReport;

--- a/lib/rtcstatsresponse.js
+++ b/lib/rtcstatsresponse.js
@@ -1,0 +1,9 @@
+function RTCStatsResponse(internalRTCStatsResponse) {
+  'use strict';
+
+  this.result = function result() {
+    return internalRTCStatsResponse.result();
+  };
+}
+
+module.exports = RTCStatsResponse;

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -7,6 +7,8 @@
 #include "datachannel.h"
 //#include "mediastream.h"
 //#include "mediastreamtrack.h"
+#include "rtcstatsreport.h"
+#include "rtcstatsresponse.h"
 
 void init(v8::Handle<v8::Object> exports) {
   rtc::InitializeSSL();
@@ -14,6 +16,8 @@ void init(v8::Handle<v8::Object> exports) {
   node_webrtc::DataChannel::Init(exports);
   //MediaStream::Init(exports);
   //MediaStreamTrack::Init(exports);
+  node_webrtc::RTCStatsReport::Init(exports);
+  node_webrtc::RTCStatsResponse::Init(exports);
 }
 
 NODE_MODULE(wrtc, init)

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -85,6 +85,14 @@ public:
     DataChannelObserver* observer;
   };
 
+  struct GetStatsEvent {
+    GetStatsEvent(NanCallback* callback, webrtc::StatsReports reports)
+    : callback(callback), reports(reports) {};
+
+    NanCallback* callback;
+    webrtc::StatsReports reports;
+  };
+
   enum AsyncEventType {
     CREATE_OFFER_SUCCESS = 0x1 << 0, // 1
     CREATE_OFFER_ERROR = 0x1 << 1, // 2
@@ -105,13 +113,14 @@ public:
     ICE_GATHERING_STATE_CHANGE = 0x1 << 16, // 65536
     NOTIFY_ADD_STREAM = 0x1 << 17, // 131072
     NOTIFY_REMOVE_STREAM = 0x1 << 18, // 262144
+    GET_STATS_SUCCESS = 0x1 << 19, // 524288
 
     ERROR_EVENT = CREATE_OFFER_ERROR | CREATE_ANSWER_ERROR |
                   SET_LOCAL_DESCRIPTION_ERROR | SET_REMOTE_DESCRIPTION_ERROR |
                   ADD_ICE_CANDIDATE_ERROR,
     SDP_EVENT = CREATE_OFFER_SUCCESS | CREATE_ANSWER_SUCCESS,
     VOID_EVENT = SET_LOCAL_DESCRIPTION_SUCCESS | SET_REMOTE_DESCRIPTION_SUCCESS |
-                 ADD_ICE_CANDIDATE_SUCCESS,
+                 ADD_ICE_CANDIDATE_SUCCESS | GET_STATS_SUCCESS,
     STATE_EVENT = SIGNALING_STATE_CHANGE | ICE_CONNECTION_STATE_CHANGE |
                   ICE_GATHERING_STATE_CHANGE
   };
@@ -154,6 +163,7 @@ public:
   static NAN_METHOD(AddStream);
   static NAN_METHOD(RemoveStream);
   */
+  static NAN_METHOD(GetStats);
   static NAN_METHOD(Close);
 
   static NAN_GETTER(GetLocalDescription);

--- a/src/rtcstatsreport.cc
+++ b/src/rtcstatsreport.cc
@@ -1,0 +1,117 @@
+#include "rtcstatsreport.h"
+
+using namespace node;
+using namespace v8;
+
+using namespace node_webrtc;
+
+Persistent<Function> RTCStatsReport::constructor;
+
+RTCStatsReport::RTCStatsReport(webrtc::StatsReport* report)
+: report(report) {};
+
+RTCStatsReport::~RTCStatsReport() {
+  report = NULL;
+}
+
+NAN_METHOD(RTCStatsReport::New) {
+  TRACE_CALL;
+  NanScope();
+
+  if (!args.IsConstructCall()) {
+    return NanThrowTypeError("Use the new operator to construct the RTCStatsReport");
+  }
+
+  Local<External> _report = Local<External>::Cast(args[0]);
+  webrtc::StatsReport* report = static_cast<webrtc::StatsReport*>(_report->Value());
+
+  RTCStatsReport* obj = new RTCStatsReport(report);
+  obj->Wrap( args.This() );
+
+  TRACE_END;
+  NanReturnValue( args.This() );
+}
+
+NAN_METHOD(RTCStatsReport::names) {
+  TRACE_CALL;
+  NanScope();
+
+  RTCStatsReport* self = ObjectWrap::Unwrap<RTCStatsReport>( args.This() );
+
+  std::vector<webrtc::StatsReport::Value> values = self->report->values;
+  Local<Array> names = NanNew<Array>(values.size());
+  for (std::vector<int>::size_type i = 0; i != values.size(); i++) {
+    webrtc::StatsReport::Value value = values[i];
+    std::string display_name = value.display_name();
+    names->Set(i, NanNew<String>(display_name));
+  }
+
+  TRACE_END;
+  NanReturnValue( names );
+}
+
+NAN_METHOD(RTCStatsReport::stat) {
+  TRACE_CALL;
+  NanScope();
+
+  RTCStatsReport* self = ObjectWrap::Unwrap<RTCStatsReport>( args.This() );
+
+  v8::String::Utf8Value _name(args[0]->ToString());
+  std::string name = std::string(*_name);
+
+  Local<Value> found = NanUndefined();
+  std::vector<webrtc::StatsReport::Value> values = self->report->values;
+  for (std::vector<int>::size_type i = 0; i != values.size(); i++) {
+    webrtc::StatsReport::Value value = values[i];
+    std::string display_name = std::string(value.display_name());
+    if (display_name.compare(name) == 0) {
+      found = NanNew<String>(value.value);
+    }
+  }
+
+  TRACE_END;
+  NanReturnValue( found );
+}
+
+NAN_GETTER(RTCStatsReport::GetTimestamp) {
+  TRACE_CALL;
+  NanScope();
+
+  RTCStatsReport *self = ObjectWrap::Unwrap<RTCStatsReport>( args.Holder() );
+  double timestamp = self->report->timestamp;
+
+  TRACE_END;
+  NanReturnValue( NanNew<Number>(timestamp) );
+}
+
+NAN_GETTER(RTCStatsReport::GetType) {
+  TRACE_CALL;
+  NanScope();
+
+  RTCStatsReport *self = ObjectWrap::Unwrap<RTCStatsReport>( args.Holder() );
+  std::string type = self->report->type;
+
+  TRACE_END;
+  NanReturnValue( NanNew<String>(type) );
+}
+
+NAN_SETTER(RTCStatsReport::ReadOnly) {
+  INFO("RTCStatsReport::ReadOnly");
+}
+
+void RTCStatsReport::Init( Handle<Object> exports ) {
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate> ( New );
+  tpl->SetClassName( NanNew( "RTCStatsReport" ) );
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  tpl->PrototypeTemplate()->Set( NanNew( "names" ),
+    NanNew<FunctionTemplate>( names )->GetFunction() );
+  tpl->PrototypeTemplate()->Set( NanNew( "stat" ),
+    NanNew<FunctionTemplate>( stat )->GetFunction() );
+
+  tpl->InstanceTemplate()->SetAccessor(NanNew("timestamp"), GetTimestamp, ReadOnly);
+  tpl->InstanceTemplate()->SetAccessor(NanNew("type"), GetType, ReadOnly);
+
+  NanAssignPersistent( constructor, tpl->GetFunction() );
+  exports->Set( NanNew( "RTCStatsReport" ), tpl->GetFunction() );
+}

--- a/src/rtcstatsreport.h
+++ b/src/rtcstatsreport.h
@@ -1,0 +1,51 @@
+#ifndef __RTCSTATSREPORT_H__
+#define __RTCSTATSREPORT_H__
+
+#include <node.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <uv.h>
+
+#include "talk/app/webrtc/statstypes.h"
+
+#include "common.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+namespace node_webrtc {
+
+class RTCStatsReport
+: public ObjectWrap
+{
+
+public:
+
+  RTCStatsReport(webrtc::StatsReport* report);
+  ~RTCStatsReport();
+
+  //
+  // Nodejs wrapping.
+  //
+  static void Init( Handle<Object> exports );
+  static Persistent<Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_METHOD(names);
+  static NAN_METHOD(stat);
+
+  static NAN_GETTER(GetTimestamp);
+  static NAN_GETTER(GetType);
+
+  static NAN_SETTER(ReadOnly);
+
+private:
+
+  webrtc::StatsReport* report;
+
+};
+
+}
+
+#endif

--- a/src/rtcstatsresponse.cc
+++ b/src/rtcstatsresponse.cc
@@ -1,0 +1,55 @@
+#include "rtcstatsresponse.h"
+#include "rtcstatsreport.h"
+
+using namespace node;
+using namespace v8;
+
+using namespace node_webrtc;
+
+Persistent<Function> RTCStatsResponse::constructor;
+
+NAN_METHOD(RTCStatsResponse::New) {
+  TRACE_CALL;
+  NanScope();
+
+  if (!args.IsConstructCall()) {
+    return NanThrowTypeError("Use the new operator to construct the RTCStatsResponse");
+  }
+
+  Local<External> _reports = Local<External>::Cast(args[0]);
+  webrtc::StatsReports* reports = static_cast<webrtc::StatsReports*>(_reports->Value());
+
+  RTCStatsResponse* obj = new RTCStatsResponse(*reports);
+  obj->Wrap( args.This() );
+
+  TRACE_END;
+  NanReturnValue( args.This() );
+}
+
+NAN_METHOD(RTCStatsResponse::result) {
+  TRACE_CALL;
+  NanScope();
+
+  RTCStatsResponse* self = ObjectWrap::Unwrap<RTCStatsResponse>( args.This() );
+
+  Local<Array> reports = NanNew<Array>(self->reports.size());
+  for (std::vector<int>::size_type i = 0; i != self->reports.size(); i++) {
+    void *copy = (void *) self->reports.at(i);
+    v8::Local<v8::Value> cargv[1];
+    cargv[0] = NanNew<v8::External>(copy);
+    reports->Set(i, NanNew(RTCStatsReport::constructor)->NewInstance(1, cargv));
+  }
+
+  TRACE_END;
+  NanReturnValue( reports );
+}
+
+void RTCStatsResponse::Init( Handle<Object> exports ) {
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate> ( New );
+  tpl->SetClassName( NanNew( "RTCStatsResponse" ) );
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->PrototypeTemplate()->Set( NanNew( "result" ),
+    NanNew<FunctionTemplate>( result )->GetFunction() );
+  NanAssignPersistent( constructor, tpl->GetFunction() );
+  exports->Set( NanNew( "RTCStatsResponse" ), tpl->GetFunction() );
+}

--- a/src/rtcstatsresponse.h
+++ b/src/rtcstatsresponse.h
@@ -1,0 +1,45 @@
+#ifndef __RTCSTATSRESPONSE_H__
+#define __RTCSTATSRESPONSE_H__
+
+#include <node.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <uv.h>
+
+#include "talk/app/webrtc/statstypes.h"
+
+#include "common.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+namespace node_webrtc {
+
+class RTCStatsResponse
+: public ObjectWrap
+{
+
+public:
+
+  RTCStatsResponse(webrtc::StatsReports reports): reports(reports) {};
+  ~RTCStatsResponse() {};
+
+  //
+  // Nodejs wrapping.
+  //
+  static void Init( Handle<Object> exports );
+  static Persistent<Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_METHOD(result);
+
+private:
+
+  webrtc::StatsReports reports;
+
+};
+
+}
+
+#endif

--- a/src/stats-observer.cc
+++ b/src/stats-observer.cc
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include "common.h"
+#include "peerconnection.h"
+#include "stats-observer.h"
+
+using namespace node_webrtc;
+
+void StatsObserver::OnComplete(const webrtc::StatsReports& reports)
+{
+  TRACE_CALL;
+  webrtc::StatsReports copy = reports;
+  PeerConnection::GetStatsEvent* data = new PeerConnection::GetStatsEvent(this->callback, copy);
+  parent->QueueEvent(PeerConnection::GET_STATS_SUCCESS, static_cast<void*>(data));
+  TRACE_END;
+}

--- a/src/stats-observer.h
+++ b/src/stats-observer.h
@@ -1,0 +1,25 @@
+#include "talk/app/webrtc/peerconnectioninterface.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+namespace node_webrtc {
+
+class PeerConnection;
+
+class StatsObserver
+  : public webrtc::StatsObserver
+{
+  private:
+    PeerConnection* parent;
+    NanCallback* callback;
+
+  public:
+    StatsObserver( PeerConnection* parent, NanCallback *callback )
+    : parent(parent), callback(callback) {};
+
+    virtual void OnComplete(const webrtc::StatsReports& reports);
+};
+
+}

--- a/test/connect.js
+++ b/test/connect.js
@@ -200,6 +200,41 @@ test('data channel connectivity', function(t) {
   t.pass('successfully called send on dc:0');
 });
 
+test('getStats', function(t) {
+  t.plan(2);
+
+  function getStats(peer, callback) {
+    peer.getStats(function(response) {
+      var reports = response.result();
+      callback(null, reports.map(function(report) {
+        var obj = {
+          timestamp: report.timestamp,
+          type: report.type
+        };
+        var names = report.names();
+        names.forEach(function(name) {
+          obj[name] = report.stat(name);
+        });
+        return obj;
+      }));
+    }, function(error) {
+      callback(error);
+    });
+  }
+
+  function done(error, reports) {
+    if (error) {
+      return t.fail(error);
+    }
+    console.log(reports);
+    t.pass('successfully called getStats');
+  }
+
+  peers.forEach(function(peer) {
+    getStats(peer, done);
+  });
+});
+
 test('close the connections', function(t) {
   t.plan(1);
   peers[0].close();


### PR DESCRIPTION
Branching off of #128, this adds minimal `getStats` support, roughly matching the interface in Chrome today.

Here's how I'm using it in my script (same as in Chrome):

``` js
peerConnection.getStats(function(response) {
  var reports = response.result();
  reports.forEach(function(report) {
    var obj = {
      timestamp: report.timestamp,
      type: report.type
    };
    var names = report.names();
    names.forEach(function(name) {
      obj[name] = report.stat(name);
    });
    console.log(obj);
  });
}, console.error.bind(console));
```

This adds a new `AsyncEventType`, `GetStatsEvent`, and a `StatsObserver`.

@modeswitch Wondering if you have any insight into how to more programmatically generate these bindings? This was pretty mechanical.
