### PR TITLE
Add prebuilt binaries for Linux and OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,52 @@ before_install:
   - sudo apt-get install -y python libnss3-dev libncurses5-dev libssl-dev libexpat-dev
   - npm install -g grunt-cli
   - npm install node-gyp -g
+  # get commit message
+  - COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
+  # put local node-pre-gyp on PATH
+  - export PATH=./node_modules/.bin/:$PATH
+  # install aws-sdk so it is available for publishing
+  - npm install aws-sdk
+  # figure out if we should publish
+  - PUBLISH_BINARY=false
+  # if we are building a tag then publish
+  - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;
+  # or if we put [publish binary] in the commit message
+  - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi;
+  - platform=$(uname -s | sed "y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/")
+  # If version is 0.9 do not publish to avoid duplicated binary error, caused by 0.9 and 0.10
+  # returning same v number in node.js.
+  - if [[ "$TRAVIS_NODE_VERSION" == '0.9' ]]; then PUBLISH_BINARY=false; fi;
 
 install:
   - npm install
+  #- node-pre-gyp package publish
+  - npm test
+
+before_script:
+  - echo "Publishing native platform Binary Package? ->" $PUBLISH_BINARY
+  # if publishing, do it
+  - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package publish; fi;
+  # cleanup
+  - node-pre-gyp clean
+  - node-gyp clean
+
+script:
+  # if publishing, test installing from remote
+  - INSTALL_RESULT=0
+  - if [[ $PUBLISH_BINARY == true ]]; then INSTALL_RESULT=$(npm install --fallback-to-build=false > /dev/null)$? || true; fi;
+  # if install returned non zero (errored) then we first unpublish and then call false so travis will bail at this line
+  - if [[ $INSTALL_RESULT != 0 ]]; then echo "returned $INSTALL_RESULT";node-pre-gyp unpublish;false; fi
+  # If success then we arrive here so lets clean up
+  - node-pre-gyp clean
+
+after_success:
+  # if success then query and display all published binaries
+  - node-pre-gyp info
 
 notifications:
   email: false
+env:
+  global:
+  - secure: WXH5UmmNHUZT1GGJFyyZsEDlJRIa4Pw989ArTxsAiOeYhll+mbXKcWbq4IKmrvFyXE9lWtl2aCU5OnR62NoatVnRj1guQJsvxqKtpuQ2wDvrTzVn1ZKZztlhffIBcjsnud3vmqCrkWesPOhqvTltaypSGxAF92ZkttTR5iv1Cw0=
+  - secure: LmX0byzsXqDC6Q+N6txwpTw8puORTBMaDFSYE2+OGbQJu06mNleYamsjTBdGTgDqBps72EiA3/GGkoarc7kyzKVP6NDMvpCwSsbDVjZkJ+OJ2wSzkD1IcHRBfsjB6NVv8rk3S5V/vwiqXM2PIaCd6o/VTGDqutf8wSxw6gYqFM4=

--- a/binding.gyp
+++ b/binding.gyp
@@ -21,7 +21,7 @@
       'variables': {
       },
       'dependencies': [],
-      'hard_depdency': 1,
+      'hard_dependency': 1,
       'type': 'none',
       'actions': [
         {
@@ -38,6 +38,7 @@
     {
       'target_name': 'wrtc',
       'dependencies': [
+        'action_before_build'
       ],
       'variables': {
         'libwebrtc_out%': '<(libwebrtc)/out/$(BUILDTYPE)/obj',
@@ -139,6 +140,17 @@
         'src/rtcstatsreport.cc',
         'src/rtcstatsresponse.cc',
         'src/stats-observer.cc'
+      ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
       ]
     }
   ]

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -1,7 +1,8 @@
-// var _webrtc = require('bindings')('webrtc.node');
-
 var path = require('path');
-var _webrtc = require('bindings')('wrtc.node');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'../package.json')));
+var _webrtc = require(binding_path);
 
 var EventTarget = require('./eventtarget');
 

--- a/package.json
+++ b/package.json
@@ -17,16 +17,26 @@
   },
   "main": "lib/index.js",
   "browser": "lib/browser.js",
+  "binary": {
+    "module_name": "wrtc",
+    "module_path": "./build/{module_name}/v{version}/{configuration}/{node_abi}-{platform}-{arch}/",
+    "remote_path": "./{module_name}/v{version}/{configuration}/",
+    "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
+    "host": "https://node-webrtc.s3.amazonaws.com"
+  },
   "engines": {
     "node": ">=0.10.x"
   },
   "dependencies": {
-    "bindings": "^1.2.1",
     "nan": "~1.3.0",
     "node-gyp": "^1.0.1",
+    "node-pre-gyp": "0.6.x",
     "node-static-alias": "^0.1.2",
     "nopt": "^2.2.0"
   },
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",
@@ -37,6 +47,7 @@
     "minimist": "0.0.8"
   },
   "scripts": {
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "node test/all.js"
   }
 }


### PR DESCRIPTION
Travis automatically builds binaries for linux x86_64.  OSX Builds can/will be published manually. Refs #168.

You can test the linux x86_64 and OSX pre-built binaries by using 
`"wrtc": "git+ssh://git@github.com:yodlr/node-webrtc.git#prebuilt"` in your package.json

Last successful build from our branch was here: https://travis-ci.org/yodlr/node-webrtc/jobs/56176259

The current published binaries include:

```
[~/dev/yodlr/node-webrtc (prebuilt_bin)]$ s3-cli ls --recursive s3://node-webrtc/
Fri Mar 27 2015 18:31:23 GMT-0700 (PDT) 1051400 wrtc/v0.0.49/Release/node-v0.11.16-linux-x64.tar.gz
Fri Mar 27 2015 18:28:31 GMT-0700 (PDT) 1562226 wrtc/v0.0.49/Release/node-v11-darwin-x64.tar.gz
Fri Mar 27 2015 18:30:58 GMT-0700 (PDT) 1050977 wrtc/v0.0.49/Release/node-v11-linux-x64.tar.gz
```
