### PR TITLE
Add automated build for 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "0.12"
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - if [[ "$TRAVIS_NODE_VERSION" == '0.9' ]]; then PUBLISH_BINARY=false; fi;
 
 install:
-  - npm install
+  - npm install --build-from-source
   #- node-pre-gyp package publish
   - npm test
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "p2p",
     "peer"
   ],
-  "version": "0.0.51",
+  "version": "0.0.52",
   "author": "Alan K <ack@modeswitch.org> (http://blog.modeswitch.org)",
   "homepage": "http://js-platform.github.io/node-webrtc/",
   "bugs": "https://github.com/js-platform/node-webrtc/issues",


### PR DESCRIPTION
This PR adds automated builds for Node 0.12.  It also correctly passes the --build-from-source flag in Travis builds.
