### PR TITLE
bwtest improved and added to npm test

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": false,
   "newcap": true,
   "noarg": true,
   "noempty": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   "eqeqeq": true,
   "immed": true,
   "indent": 2,
-  "latedef": false,
+  "latedef": "nofunc",
   "newcap": true,
   "noarg": true,
   "noempty": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "p2p",
     "peer"
   ],
-  "version": "0.0.52",
+  "version": "0.0.53",
   "author": "Alan K <ack@modeswitch.org> (http://blog.modeswitch.org)",
   "homepage": "http://js-platform.github.io/node-webrtc/",
   "bugs": "https://github.com/js-platform/node-webrtc/issues",

--- a/test/all.js
+++ b/test/all.js
@@ -1,3 +1,4 @@
 require('./create-offer');
 require('./sessiondesc');
 require('./connect');
+require('./bwtest').tape();

--- a/test/bwtest.html
+++ b/test/bwtest.html
@@ -1,5 +1,9 @@
 <!--
 
+    This is to run the bwtest in a browser to compare with node-webrtc.
+    It works by bundling the test code with browserify and then loading
+    the script from this html.
+
     PREPARING THE BROWSERIFY BUNDLE:
 
     $ npm install browserify

--- a/test/bwtest.js
+++ b/test/bwtest.js
@@ -3,6 +3,7 @@
 var tape = require('tape');
 var args = require('minimist')(process.argv.slice(2));
 
+
 module.exports = bwtest;
 bwtest.tape = bwtape;
 

--- a/test/bwtest.js
+++ b/test/bwtest.js
@@ -1,70 +1,208 @@
 'use strict';
 
-/**
- * define window with webrtc functions for simple-peer
- */
-if (typeof(window) === 'undefined') {
-    var wrtc = require('..');
-    global.window = {
-        RTCPeerConnection: wrtc.RTCPeerConnection,
-        RTCSessionDescription: wrtc.RTCSessionDescription,
-        RTCIceCandidate: wrtc.RTCIceCandidate,
-        // Firefox does not trigger "negotiationneeded"
-        // this is a workaround to make simple-peer trigger the negotiation
-        mozRTCPeerConnection: wrtc.RTCPeerConnection,
-    };
+var tape = require('tape');
+var args = require('minimist')(process.argv.slice(2));
+
+module.exports = bwtest;
+bwtest.tape = bwtape;
+
+
+if (require.main === module) {
+    main();
 }
 
-var SimplePeer = require('simple-peer');
+
+/**
+ * called when running this script directly from cli
+ */
+function main() {
+    if (typeof(args.iceConfig) === 'string') {
+        // parse json of iceConfig to allow running like this:
+        // node test/bwtest --iceConfig '{"ordered": false}'
+        args.iceConfig = JSON.parse(args.iceConfig);
+    }
+    console.log('bwtest args:', args);
+    bwtest(args);
+}
 
 
-function bwtest(peer1, peer2) {
-    var START_TIME = Date.now();
-    var BUFFERED_DELAY_MS = 5;
-    var NPACKETS = 5000;
-    var PACKET_SIZE = 16 * 1024;
-    var CONGEST_HIGH_THRESHOLD = 1 * 1024 * 1024;
-    var CONGEST_LOW_THRESHOLD = 256 * 1024;
-    var buffer = new ArrayBuffer(PACKET_SIZE);
+/**
+ * setup tape tests for bwtest
+ */
+function bwtape() {
+    tape('bwtest default', function(t) {
+        t.plan(1);
+        bwtest({
+            packetCount: 500,
+        }, function(err) {
+            t.error(err, 'bwtest check for error');
+        });
+    });
+
+    tape('bwtest no buffering', function(t) {
+        t.plan(1);
+        bwtest({
+            packetCount: 500,
+            congestHighThreshold: 0,
+            congestLowThreshold: 0
+        }, function(err) {
+            t.error(err, 'bwtest check for error');
+        });
+    });
+
+    tape('bwtest unordered and unreliable', function(t) {
+        t.plan(1);
+        bwtest({
+            packetCount: 500,
+            iceConfig: {
+                ordered: false,
+                maxRetransmits: 5
+            }
+        }, function(err) {
+            t.error(err, 'bwtest check for error');
+        });
+    });
+}
+
+
+
+/**
+ *
+ * BWTEST
+ *
+ * run a webrtc bandwidth test with two peers running in this process.
+ *
+ * @param options (optional) - see defaults inside for list of options.
+ * @param callback function(err) called on success/failure.
+ *
+ */
+function bwtest(options, callback) {
+
+    // options is optional
+    if (typeof(options) === 'function') {
+        callback = options;
+        options = null;
+    }
+
+    // defaults
+    callback = callback || function() {};
+    options = options || {};
+    options.packetCount = options.packetCount || 5000;
+    options.packetSize = options.packetSize || 16 * 1024;
+    options.bufferedDelayMs = options.bufferedDelayMs || 5;
+    options.congestHighThreshold = options.congestHighThreshold || 1024 * 1024;
+    options.congestLowThreshold = options.congestLowThreshold || 256 * 1024;
+    options.iceConfig = options.iceConfig || defaultIceConfig();
+
+    var buffer = new ArrayBuffer(options.packetSize);
     var n = 0;
     var congested = 0;
     var stats = {
+        startTime: 0,
         count: 0,
         bytes: 0,
         congestCount: 0,
         congestTime: 0
     };
 
-    function info() {
-        var now = Date.now();
-        if (congested) {
-            stats.congestTime += Date.now() - congested;
-            congested = now;
-        }
-        var took = (now - START_TIME) / 1000;
-        var bufferedAmount = peer1._channel && peer1._channel.bufferedAmount;
-        return 'sent ' + n + ' received ' + stats.count + '. ' +
-            'congestion #' + stats.congestCount + ' ' +
-            (stats.congestTime / 1024).toFixed(3) + ' seconds. ' +
-            (bufferedAmount ? 'bufferedAmount ' + bufferedAmount + '. ' : '') +
-            'took ' + took.toFixed(3) + ' seconds. ' +
-            'bandwidth ' + (stats.bytes / took / 1024).toFixed(0) + ' KB/s. ';
-    }
-
-    peer2.on('data', function(data) {
-        stats.count += 1;
-        stats.bytes += data.length;
-        if (stats.count >= NPACKETS) {
-            console.log('RECEIVE DONE!', info());
-            peer1.destroy();
-            peer2.destroy();
-        }
+    // setup two peers with simple-peer
+    var SimplePeer = requireSimplePeer();
+    var peer1 = new SimplePeer();
+    var peer2 = new SimplePeer({
+        initiator: true,
+        config: options.iceConfig
     });
 
+    // when peer1 has signaling data, give it to peer2, and vice versa
+    peer1.on('signal', peer2.signal.bind(peer2));
+    peer2.on('signal', peer1.signal.bind(peer1));
+
+    // wait for 'connect' event before using the data channel
+    peer1.on('error', failure);
+    peer2.on('error', failure);
+    peer1.on('connect', start);
+    peer2.on('data', receive);
+
+
+
+    // functions //
+
+    /**
+     * start the test once peers are connected
+     */
+    function start() {
+        stats.startTime = Date.now();
+        send();
+    }
+
+
+    /**
+     * send next packet and recurse
+     */
+    function send() {
+        if (n >= options.packetCount) {
+            console.log('SEND DONE!', info());
+            return;
+        }
+        if (n % 100 === 0) {
+            console.log('SENDING:', info());
+        }
+        if (congestion()) {
+            setTimeout(send, options.bufferedDelayMs);
+            return;
+        }
+        peer1.send(buffer, function(err) {
+            if (err) {
+                return failure(err);
+            }
+            n += 1;
+            if (global.setImmediate) {
+                global.setImmediate(send);
+            } else {
+                setTimeout(send, 0);
+            }
+        });
+    }
+
+
+    /**
+     * callback for the receiver to update stats and finish the test
+     */
+    function receive(data) {
+        stats.count += 1;
+        stats.bytes += data.length;
+        if (stats.count >= options.packetCount) {
+            console.log('RECEIVE DONE!', info());
+            // closing the channels so the process can exit
+            peer1.destroy();
+            peer2.destroy();
+            callback();
+        }
+    }
+
+
+    /**
+     * failure handler
+     */
+    function failure(err) {
+
+        // make sure to call the callback with error, even if anything here will throw
+        setTimeout(callback.bind(null, err), 0);
+
+        console.error('ERROR!', info(), err.stack || err);
+        // closing the channels so the process can exit
+        peer1.destroy();
+        peer2.destroy();
+    }
+
+
+    /**
+     * handle channel congestion using bufferedAmount
+     */
     function congestion() {
         var bufferedAmount = peer1._channel && peer1._channel.bufferedAmount || 0;
-        if ((bufferedAmount > CONGEST_HIGH_THRESHOLD) ||
-            (congested && bufferedAmount > CONGEST_LOW_THRESHOLD)) {
+        if ((bufferedAmount > options.congestHighThreshold) ||
+            (congested && bufferedAmount > options.congestLowThreshold)) {
             if (!congested) {
                 congested = Date.now();
             }
@@ -78,48 +216,57 @@ function bwtest(peer1, peer2) {
         return congested;
     }
 
-    function send() {
-        if (n >= NPACKETS) {
-            console.log('SEND DONE!', info());
-            return;
+
+
+    /**
+     * return information string on the test progress
+     */
+    function info() {
+        var now = Date.now();
+        if (congested) {
+            stats.congestTime += Date.now() - congested;
+            congested = now;
         }
-        if (n % 100 === 0) {
-            console.log('SENDING:', info());
-        }
-        if (congestion()) {
-            setTimeout(send, BUFFERED_DELAY_MS);
-            return;
-        }
-        peer1.send(buffer, function(err) {
-            if (err) {
-                console.error('ERROR!', info(), err.stack || err);
-                return;
-            }
-            n += 1;
-            if (global.setImmediate) {
-                global.setImmediate(send);
-            } else {
-                setTimeout(send, 0);
-            }
-        });
+        var took = (now - stats.startTime) / 1000;
+        var bufferedAmount = peer1._channel && peer1._channel.bufferedAmount;
+        return 'sent ' + n + ' received ' + stats.count + '. ' +
+            'congestion #' + stats.congestCount + ' ' +
+            (stats.congestTime / 1024).toFixed(3) + ' seconds. ' +
+            (bufferedAmount ? 'bufferedAmount ' + bufferedAmount + '. ' : '') +
+            'took ' + took.toFixed(3) + ' seconds. ' +
+            'bandwidth ' + (stats.bytes / took / 1024).toFixed(0) + ' KB/s. ';
     }
 
-    send();
-}
 
-function init(callback) {
-    var INITIATOR_CONFIG = {
-        initiator: true,
-        config: {
-            iceServers: [{
-                url: 'stun:23.21.150.121'
-            }],
+    /**
+     * define window with webrtc functions before loading simple-peer
+     */
+    function requireSimplePeer() {
+        if (typeof(window) === 'undefined') {
+            var wrtc = require('..');
+            global.window = {
+                RTCPeerConnection: wrtc.RTCPeerConnection,
+                RTCSessionDescription: wrtc.RTCSessionDescription,
+                RTCIceCandidate: wrtc.RTCIceCandidate,
+                // node-webrtc and Firefox do not trigger "negotiationneeded"
+                // this is a workaround to make simple-peer trigger the negotiation
+                mozRTCPeerConnection: wrtc.RTCPeerConnection,
+            };
+        }
+        return require('simple-peer');
+    }
 
+
+    /**
+     * default ice config is just here for documenting the options - see inside.
+     */
+    function defaultIceConfig() {
+        return {
             /*
              * data channels are ordered by default - using unordered channel improves
              * performance but will likely require ordering in another app layer
              */
-            ordered: false,
+            // ordered: false,
 
             /*
              * data channels are reliable by default - using either maxRetransmits
@@ -127,17 +274,11 @@ function init(callback) {
              */
             // maxRetransmits: 5,
             // maxPacketLifeTime: 3000,
-        }
-    };
-    var peer1 = new SimplePeer(INITIATOR_CONFIG);
-    var peer2 = new SimplePeer();
 
-    // when peer1 has signaling data, give it to peer2, and vice versa
-    peer1.on('signal', peer2.signal.bind(peer2));
-    peer2.on('signal', peer1.signal.bind(peer1));
-
-    // wait for 'connect' event before using the data channel
-    peer1.on('connect', callback.bind(null, peer1, peer2));
+            /*
+             * iceServers with stun urls. not needed for this in-process test.
+             */
+            // iceServers: [{url: 'stun:23.21.150.121'}],
+        };
+    }
 }
-
-init(bwtest);


### PR DESCRIPTION
- when running directly as main script will use minimist args, so can
  run like: node test/bwtest —packetCount 1000
- npm test runs 3 short bwtest variants (with tape). the current
  variants are: default, no buffering, unordered and unreliable.
