### PR TITLE
Link statically built boringssl over nss

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -106,8 +106,9 @@
               '../<(libwebrtc_out)/webrtc/base/librtc_base_approved.a',
               '../<(libwebrtc_out)/chromium/src/net/third_party/nss/libcrssl.a',
               '../<(libwebrtc_out)/chromium/src/third_party/usrsctp/libusrsctplib.a',
+              '../<(libwebrtc_out)/chromium/src/third_party/boringssl/libboringssl.a',
 #             '-lssl',
-              '-lnss3',
+#             '-lnss3',
             ]
           }],
           ['OS=="mac"', {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "minimist": "0.0.8"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
+    "install": "node-pre-gyp install --build-from-source",
     "test": "node test/all.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "minimist": "0.0.8"
   },
   "scripts": {
-    "install": "node-pre-gyp install --build-from-source",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "node test/all.js"
   }
 }


### PR DESCRIPTION
- Nss on ubuntu 14.04 has no compatible ciphers with firefox 39
- BoringSSL has compatible ciphers so this fixes the bridge example for firefox
- Requires commit f632d8d3203af25bb8bdd7900a8d7875085c9143 of libwebrtc
- See pull request on libwebrtc for more details : https://github.com/js-platform/libwebrtc/pull/12
