### PR TITLE
removed link to libcrssl.a to fix linux build error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -104,7 +104,7 @@
               '../<(libwebrtc_out)/webrtc/p2p/librtc_p2p.a',
               '../<(libwebrtc_out)/webrtc/base/librtc_base.a',
               '../<(libwebrtc_out)/webrtc/base/librtc_base_approved.a',
-              '../<(libwebrtc_out)/chromium/src/net/third_party/nss/libcrssl.a',
+#             '../<(libwebrtc_out)/chromium/src/net/third_party/nss/libcrssl.a',
               '../<(libwebrtc_out)/chromium/src/third_party/usrsctp/libusrsctplib.a',
               '../<(libwebrtc_out)/chromium/src/third_party/boringssl/libboringssl.a',
 #             '-lssl',


### PR DESCRIPTION
```
Updating projects from gyp files...
.: Building libwebrtc ... 
ninja: Entering directory `out/Release'
[621/621] LINK wrtc_build
: Build complete

  TOUCH Release/obj.target/action_before_build.stamp
  CXX(target) Release/obj.target/wrtc/src/binding.o
  CXX(target) Release/obj.target/wrtc/src/create-offer-observer.o
  CXX(target) Release/obj.target/wrtc/src/create-answer-observer.o
  CXX(target) Release/obj.target/wrtc/src/set-local-description-observer.o
  CXX(target) Release/obj.target/wrtc/src/set-remote-description-observer.o
  CXX(target) Release/obj.target/wrtc/src/peerconnection.o
  CXX(target) Release/obj.target/wrtc/src/datachannel.o
  CXX(target) Release/obj.target/wrtc/src/rtcstatsreport.o
  CXX(target) Release/obj.target/wrtc/src/rtcstatsresponse.o
  CXX(target) Release/obj.target/wrtc/src/stats-observer.o
  SOLINK_MODULE(target) Release/obj.target/wrtc.node
g++: error: ../third_party/libwebrtc/out/Release/obj/chromium/src/net/third_party/nss/libcrssl.a: No such file or directory
wrtc.target.mk:200: recipe for target 'Release/obj.target/wrtc.node' failed
make: *** [Release/obj.target/wrtc.node] Error 1
```

I've encountered build errors in Debian with the latest version using npm install. It built successfully after this change followed by 'node-pre-gyp install --fallback-to-build'. Hopefully this is the correct fix.
