### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To install prerequisites using the homebrew package manager,
 
 ```
 brew update
-brew install git openssl pkg-config openssl ncurses nss expat
+brew install git openssl pkg-config openssl homebrew/dupes/ncurses nss expat
 ```
 
 Some of these libraries may be installed by default. Package names for these libraries may differ between distributions.


### PR DESCRIPTION
ncurses can't be installed directly from brew, use tap instead because running the current brew command returns:

``` bash
$ brew install ncurses
Error: No available formula with the name "ncurses"
==> Searching for similarly named formulae...
This similarly named formula was found:
homebrew/dupes/ncurses (installed)
To install it, run:
  brew install homebrew/dupes/ncurses
==> Searching taps...
Error: No formulae found in taps.
```
