### PR TITLE
Update README.md: add more prerequisites for Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Some open issues have bounties assocaited with them. Once you patch is merged, y
 
 To install prerequisites with the apt-get package manager,
 
-`apt-get install python2.7 git-all pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev  `
+`apt-get install python2.7 git-all pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev libudev-dev libdrm-dev libgconf2-dev libgcrypt11-dev libpci-dev libxtst-dev g++ libnss3-dev libasound2-dev libpulse-dev libjpeg62-dev libxv-dev libgtk2.0-dev libexpat1-dev`
 
 ### CentOS/Fedora/RHEL
 


### PR DESCRIPTION
I have tried to install wrtc v0.0.59 npm package following instructions in README.md, but did not succeed. 
OS: Linux Mint 17.2. 
Node: I have tried with v0.12.0, v0.12.7, v4.2.2 and v5.0.0.

So looking on the Internet I came across: https://hub.docker.com/r/tsujio/node-webrtc/. Where it is explained that in order to install wrtc package I need to install more system libraries. As what I did and after that I was able to install wrtc without problem with Node v0.12.7.
