### PR TITLE
Addition of Promise API support

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -199,75 +199,181 @@ function RTCPeerConnection(configuration, constraints) {
     }
   });
 
-  //
-  // PeerConnection methods
-  //
+  this.createOffer = function createOffer(){
+    var call = function call(options, successCallback, failureCallback) {
+      queueOrRun({
+        func: 'createOffer',
+        args: [options],
+        wait: true,
+        onSuccess: function(sdp) {
+          successCallback.call(this, new RTCSessionDescription({type: 'offer', sdp: sdp}));
+        },
+        onError: failureCallback
+      });
+    };
 
-  this.createOffer = function createOffer(successCallback, failureCallback, options) {
-    options = options || {};
-
-    // FIXME: complain if onError is undefined
-    queueOrRun({
-      func: 'createOffer',
-      args: [options],
-      wait: true,
-      onSuccess: function(sdp) {
-        successCallback.call(this, new RTCSessionDescription({type: 'offer', sdp: sdp}));
-      },
-      onError: failureCallback
-    });
+    if (arguments.length === 0 || arguments.length === 1 && typeof arguments[0] === 'object') {      
+      // Promise-based call.
+      var options = (arguments.length === 1) ? arguments[0] : {};
+      return new Promise(function createOfferPromise(resolve, reject) {
+        call(options, resolve, reject);
+      });
+    } else if (arguments.length >= 2
+        && typeof arguments[0] === 'function'
+        && typeof arguments[1] === 'function'
+        && (arguments.length === 2 || typeof arguments[2] === 'object')) {
+      // Legacy method.
+      var options = (arguments.length === 3) ? arguments[2] : {};
+      call(options, arguments[0], arguments[1]);
+    } else {
+      throw new Error('Invalid call to createOffer - function must either have prototype'
+        + ' ([config]) or (successCallback, failureCallback, [config]).');
+    }
   };
 
-  this.createAnswer = function createAnswer(successCallback, failureCallback, options) {
-    options = options || {};
+  this.createAnswer = function createAnswer(){
+    var call = function call(options, successCallback, failureCallback) {
+      queueOrRun({
+        func: 'createAnswer',
+        args: [options],
+        wait: true,
+        onSuccess: function(sdp) {
+          successCallback.call(this, new RTCSessionDescription({type: 'answer', sdp: sdp}));
+        },
+        onError: failureCallback
+      });
+    };
 
-    // FIXME: complain if onError is undefined
-    queueOrRun({
-      func: 'createAnswer',
-      args: [options],
-      wait: true,
-      onSuccess: function(sdp) {
-        successCallback.call(this, new RTCSessionDescription({type: 'answer', sdp: sdp}));
-      },
-      onError: failureCallback
-    });
+    if (arguments.length === 0 || arguments.length === 1 && typeof arguments[0] === 'object') {      
+      // Promise-based call.
+      var options = (arguments.length === 1) ? arguments[0] : {};
+      return new Promise(function createAnswerPromise(resolve, reject) {
+        call(options, resolve, reject);
+      });
+    } else if (arguments.length >= 2
+        && typeof arguments[0] === 'function'
+        && typeof arguments[1] === 'function') {
+      // Legacy method.
+      call({}, arguments[0], arguments[1]);
+    } else {
+      throw new Error('Invalid call to createAnswer - function must either have prototype'
+        + ' (void) or (successCallback, failureCallback).');
+    }
   };
 
-  this.setLocalDescription = function setLocalDescription(description, successCallback, failureCallback) {
-    localType = description.type;
+  this.setLocalDescription = function setLocalDescription(){
+    var call = function call(description, successCallback, failureCallback) {
+      localType = description.type;
 
-    queueOrRun({
-      func: 'setLocalDescription',
-      args: [description],
-      wait: true,
-      onSuccess: successCallback,
-      onError: failureCallback
-    });
+      queueOrRun({
+        func: 'setLocalDescription',
+        args: [description],
+        wait: true,
+        onSuccess: successCallback,
+        onError: failureCallback
+      });
+    };
+
+    var error = new Error('Invalid call to setLocalDescription - function must either have prototype'
+        + ' (description) or (description, successCallback, failureCallback).');
+
+    if (arguments.length >= 1 && typeof arguments[0] === 'object') {      
+      var description = arguments[0];
+
+      if(arguments.length === 1) {
+        // Promise-based call.
+        return new Promise(function setLocalDescriptionPromise(resolve, reject) {
+          call(description, resolve, reject);
+        });
+      } else if (arguments.length >= 3
+          && typeof arguments[1] === 'function'
+          && typeof arguments[2] === 'function') {
+        // Legacy method.
+        call(description, arguments[1], arguments[2]);
+      } else {
+        throw error;
+      }
+
+    } else {
+      throw error;
+    }
   };
 
-  this.setRemoteDescription = function setRemoteDescription(description, successCallback, failureCallback) {
-    remoteType = description.type;
+  this.setRemoteDescription = function setRemoteDescription(){
+    var call = function call(description, successCallback, failureCallback) {
+      remoteType = description.type;
 
-    queueOrRun({
-      func: 'setRemoteDescription',
-      args: [description],
-      wait: true,
-      onSuccess: successCallback,
-      onError: failureCallback
-    });
+      queueOrRun({
+        func: 'setRemoteDescription',
+        args: [description],
+        wait: true,
+        onSuccess: successCallback,
+        onError: failureCallback
+      });
+    };
+
+    var error = new Error('Invalid call to setRemoteDescription - function must either have prototype'
+        + ' (description) or (description, successCallback, failureCallback).');
+
+    if (arguments.length >= 1 && typeof arguments[0] === 'object') {      
+      var description = arguments[0];
+
+      if(arguments.length === 1) {
+        // Promise-based call.
+        return new Promise(function setRemoteDescriptionPromise(resolve, reject) {
+          call(description, resolve, reject);
+        });
+      } else if (arguments.length >= 3
+          && typeof arguments[1] === 'function'
+          && typeof arguments[2] === 'function') {
+        // Legacy method.
+        call(description, arguments[1], arguments[2]);
+      } else {
+        throw error;
+      }
+
+    } else {
+      throw error;
+    }
   };
 
-  this.addIceCandidate = function addIceCandidate(candidate, successCallback, failureCallback) {
-    queueOrRun({
-      func: 'addIceCandidate',
-      args: [{'candidate':     candidate.candidate,
-              'sdpMid':        candidate.sdpMid,
-              'sdpMLineIndex': candidate.sdpMLineIndex
-             }],
-      wait: true,
-      onSuccess: successCallback,
-      onError: failureCallback
-    });
+  this.addIceCandidate = function addIceCandidate(){
+    var call = function call(candidate, successCallback, failureCallback) {
+      queueOrRun({
+        func: 'addIceCandidate',
+        args: [{'candidate':     candidate.candidate,
+                'sdpMid':        candidate.sdpMid,
+                'sdpMLineIndex': candidate.sdpMLineIndex
+               }],
+        wait: true,
+        onSuccess: successCallback,
+        onError: failureCallback
+      });
+    };
+
+    var error = new Error('Invalid call to addIceCandidate - function must either have prototype'
+        + ' (candidate) or (candidate, successCallback, failureCallback).');
+
+    if (arguments.length >= 1 && typeof arguments[0] === 'object') {      
+      var candidate = arguments[0];
+
+      if(arguments.length === 1) {
+        // Promise-based call.
+        return new Promise(function addIceCandidatePromise(resolve, reject) {
+          call(candidate, resolve, reject);
+        });
+      } else if (arguments.length >= 3
+          && typeof arguments[1] === 'function'
+          && typeof arguments[2] === 'function') {
+        // Legacy method.
+        call(candidate, arguments[1], arguments[2]);
+      } else {
+        throw error;
+      }
+
+    } else {
+      throw error;
+    }
   };
 
   this.createDataChannel = function createDataChannel(label, dataChannelDict) {


### PR DESCRIPTION
Fixes issue #243 to add Promise support for parity with the current W3C draft. I've tried to maintain compatibility with older versions of node - Promise code shouldn't be accessed at all if the legacy API is used.

I haven't added any tests for the new methods - I understand that tests for this new functionality would fail on older versions of node, such as in the travis-multirunner test harness.

If there are any further changes to make then I'd be happy - apologies it's taken a while!
