### PR TITLE
Add g++ as a pre-requisite (apt dependency) on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Some open issues have bounties assocaited with them. Once you patch is merged, y
 
 * python2
 * git
+* g++
 * pkg-config
 * libncurses-devel
 * libssl-devel
@@ -38,7 +39,7 @@ Some open issues have bounties assocaited with them. Once you patch is merged, y
 
 To install prerequisites with the apt-get package manager,
 
-`apt-get install python2.7 git-all pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev  `
+`apt-get install python2.7 git-all g++ pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev`
 
 ### CentOS/Fedora/RHEL
 


### PR DESCRIPTION
I'm not quite familiar with `node-gyp` and native addons to Node.js.

But @hackedbellini was trying to install `npm i wrtc` on a brand new
Ubuntu Trusty (14.04) and was having some issues on installation,
it seemed as `g++` was missing, so the whole installation failed.

Another evidence that `g++` is needed here is that it is listed on
the [`Dockerfile`](https://github.com/js-platform/node-webrtc/blob/develop/Dockerfile) dependencies.
