### PR TITLE
Add another build requirement: libtinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Some open issues have bounties assocaited with them. Once you patch is merged, y
 * libssl-devel
 * libnss-devel
 * libexpat-devel
+* libtinfo-devel (in CentOS, the libtinfo library is provided in the libncurses-devel package)
 
 ### Debian/Ubuntu
 
 To install prerequisites with the apt-get package manager,
 
-`apt-get install python2.7 git-all pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev  `
+`apt-get install python2.7 git-all pkg-config libncurses5-dev libssl-dev libnss3-dev libexpat-dev libtinfo-dev`
 
 ### CentOS/Fedora/RHEL
 


### PR DESCRIPTION
In order to successfully build, I needed the libtinfo.so.5 library. This is found in libtinfo-dev on Ubuntu, and libtinfo on Arch. I don't have access to a CentOS machine, but from what I could find, the libtinfo library is already provided in the ncurses library for RPM-based distros.
