### PR TITLE
Update nan to fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "fs-extra": "^0.18.0",
-    "nan": "^2.1.0",
+    "nan": "^2.3.2",
     "node-gyp": "^3.0.3",
     "node-pre-gyp": "0.6.x",
     "node-static-alias": "^0.1.2",
@@ -45,7 +45,7 @@
     "grunt-tape": "~0.0.2",
     "simple-peer": "^5.0.0",
     "tape": "~2.4.2",
-    "ws": "~0.4.31",
+    "ws": "^1.1.0",
     "node-static": "^0.7.3",
     "minimist": "0.0.8"
   },

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -351,13 +351,10 @@ void DataChannel::Init(Handle<Object> exports) {
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
   tpl->SetClassName(Nan::New("DataChannel").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->PrototypeTemplate()->Set(Nan::New("close").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(Close)->GetFunction());
-  tpl->PrototypeTemplate()->Set(Nan::New("shutdown").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(Shutdown)->GetFunction());
 
-  tpl->PrototypeTemplate()->Set(Nan::New("send").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(Send)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "close", Close);
+  Nan::SetPrototypeMethod(tpl, "shutdown", Shutdown);
+  Nan::SetPrototypeMethod(tpl, "send", Send);
 
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("bufferedAmount").ToLocalChecked(), GetBufferedAmount, ReadOnly);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("label").ToLocalChecked(), GetLabel, ReadOnly);

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -509,32 +509,15 @@ void PeerConnection::Init(Handle<Object> exports) {
   tpl->SetClassName(Nan::New("PeerConnection").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("createOffer").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(CreateOffer)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("createAnswer").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(CreateAnswer)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("setLocalDescription").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(SetLocalDescription)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("setRemoteDescription").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(SetRemoteDescription)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("getStats").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(GetStats)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("updateIce").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(UpdateIce)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("addIceCandidate").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(AddIceCandidate)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("createDataChannel").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(CreateDataChannel)->GetFunction());
-
-  tpl->PrototypeTemplate()->Set(Nan::New("close").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(Close)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "createOffer", CreateOffer);
+  Nan::SetPrototypeMethod(tpl, "createAnswer", CreateAnswer);
+  Nan::SetPrototypeMethod(tpl, "setLocalDescription", SetLocalDescription);
+  Nan::SetPrototypeMethod(tpl, "setRemoteDescription", SetRemoteDescription);
+  Nan::SetPrototypeMethod(tpl, "getStats", GetStats);
+  Nan::SetPrototypeMethod(tpl, "updateIce", UpdateIce);
+  Nan::SetPrototypeMethod(tpl, "addIceCandidate", AddIceCandidate);
+  Nan::SetPrototypeMethod(tpl, "createDataChannel", CreateDataChannel);
+  Nan::SetPrototypeMethod(tpl, "close", Close);
 
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("localDescription").ToLocalChecked(), GetLocalDescription, ReadOnly);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("remoteDescription").ToLocalChecked(), GetRemoteDescription, ReadOnly);

--- a/src/rtcstatsreport.cc
+++ b/src/rtcstatsreport.cc
@@ -111,10 +111,8 @@ void RTCStatsReport::Init(Handle<Object> exports) {
   tpl->SetClassName(Nan::New("RTCStatsReport").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("names").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(names)->GetFunction());
-  tpl->PrototypeTemplate()->Set(Nan::New("stat").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(stat)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "names", names);
+  Nan::SetPrototypeMethod(tpl, "stat", stat);
 
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("timestamp").ToLocalChecked(), GetTimestamp, ReadOnly);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("type").ToLocalChecked(), GetType, ReadOnly);

--- a/src/rtcstatsresponse.cc
+++ b/src/rtcstatsresponse.cc
@@ -55,8 +55,7 @@ void RTCStatsResponse::Init(Handle<Object> exports) {
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate> (New);
   tpl->SetClassName(Nan::New("RTCStatsResponse").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  tpl->PrototypeTemplate()->Set(Nan::New("result").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(result)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "result", result);
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("RTCStatsResponse").ToLocalChecked(), tpl->GetFunction());
 }


### PR DESCRIPTION
Node 6 dumps a heap of deprecation warnings when this lib is included:

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.
==== JS stack trace =========================================
Security context: 0x16917dac9fa9 <JS Object>#0#
    1: .node [module.js:568] [pc=0x43fc98a3704] (this=0x206b7dfdf3e9 <an Object with map 0x31b8ee17609>#1#,module=0x34b4d60d4d59 <a Module with map 0x31b8ee17be1>#2#,filename=0x34b4d60d4d21 <String[61]: /code/build/wrtc/v0.0.59/Release/node-v48-linux-x64/wrtc.node>)
...
```

It also warns that it will not work altogether in node 7.

[Another project with the same issue](https://github.com/Automattic/node-canvas/issues/758) narrowed it down to an outdated version of nan. It'd be great to be able to merge this and cut a release to fix those noisy warnings that are blowing up my app logs.

Edit: It looks like the old version of `ws` that is used for testing also spews the deprecation warning as it uses `nan@1.0.0`, so I updated that as well.
