### PR TITLE
Use a "fake" AudioDeviceModule

### DIFF
--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -6,6 +6,8 @@
 #include "webrtc/api/mediaconstraintsinterface.h"
 #include "webrtc/api/test/fakeconstraints.h"
 #include "webrtc/base/refcount.h"
+#include "webrtc/system_wrappers/include/clock.h"
+#include "webrtc/test/fake_audio_device.h"
 
 #include "common.h"
 #include "create-answer-observer.h"
@@ -58,7 +60,8 @@ PeerConnection::PeerConnection()
   constraints.AddMandatory(webrtc::MediaConstraintsInterface::kOfferToReceiveAudio, webrtc::MediaConstraintsInterface::kValueFalse);
   constraints.AddMandatory(webrtc::MediaConstraintsInterface::kOfferToReceiveVideo, webrtc::MediaConstraintsInterface::kValueFalse);
 
-  _jinglePeerConnectionFactory = webrtc::CreatePeerConnectionFactory(_workerThread, _signalingThread, nullptr, nullptr, nullptr);
+  _audioDeviceModule = new webrtc::test::FakeAudioDevice(webrtc::Clock::GetRealTimeClock(), "/dev/null", 1.0f);
+  _jinglePeerConnectionFactory = webrtc::CreatePeerConnectionFactory(_workerThread, _signalingThread, _audioDeviceModule, nullptr, nullptr);
   _jinglePeerConnection = _jinglePeerConnectionFactory->CreatePeerConnection(configuration, &constraints, nullptr, nullptr, this);
 
   uv_mutex_init(&lock);

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -185,6 +185,7 @@ class PeerConnection
   rtc::scoped_refptr<SetLocalDescriptionObserver> _setLocalDescriptionObserver;
   rtc::scoped_refptr<SetRemoteDescriptionObserver> _setRemoteDescriptionObserver;
 
+  webrtc::AudioDeviceModule *_audioDeviceModule;
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> _jinglePeerConnection;
   rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> _jinglePeerConnectionFactory;
 


### PR DESCRIPTION
This is just one possible approach for improving #285. As mentioned in that issue, on platforms that provide neither PulseAudio nor ALSA, the default AudioDeviceModule will fail. One work around is to use FakeAudioDevice (I've confirmed that this succeeds on the aforementioned platforms). Before merging, I think it makes sense to
- Test with FakeAudioCaptureModule (this was not originally working for me, but I've since updated libwebrtc.a—so maybe it will work again).
- Test with audio MediaStreamTracks (make sure passing "/dev/null" to the FakeAudioDevice isn't an issue)
- Create a plan for choosing between AudioDeviceModule implementations, e.g.

``` js
const wrtc = require('wrtc');
const pc = new wrtc.RTCPeerConnection({
  audioDeviceModule: 'fake',  // or, 'default'
  iceServers: []
});
```
- Still need to do the `nullptr` check on the return value of CreatePeerConnectionFactory.
