### PR TITLE
Drop CPU usage as soon as connection is closed

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -370,8 +370,12 @@ function RTCPeerConnection(configuration, constraints) {
       args: [label, dataChannelDict]
     });
 
-    dataChannels[label] = channel;
-    return new RTCDataChannel(channel);
+    // channel will be undefined if dataChannel was closed before calling this function
+    // (see peerconnection.cc)
+    if (channel) {  
+        dataChannels[label] = channel;
+        return new RTCDataChannel(channel);
+    }
   };
 
   this.getStats = function getStats(onSuccess, onFailure) {

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -436,6 +436,9 @@ NAN_METHOD(PeerConnection::Close) {
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
   self->_jinglePeerConnection->Close();
 
+  self->_jinglePeerConnection = nullptr;
+  self->_jinglePeerConnectionFactory = nullptr;
+
   TRACE_END;
   info.GetReturnValue().Set(Nan::Undefined());
 }

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -264,7 +264,9 @@ NAN_METHOD(PeerConnection::CreateOffer) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
-  self->_jinglePeerConnection->CreateOffer(self->_createOfferObserver, nullptr);
+  if (self->_jinglePeerConnection != nullptr) {
+    self->_jinglePeerConnection->CreateOffer(self->_createOfferObserver, nullptr);
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::Undefined());
@@ -275,7 +277,9 @@ NAN_METHOD(PeerConnection::CreateAnswer) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
-  self->_jinglePeerConnection->CreateAnswer(self->_createAnswerObserver, nullptr);
+  if (self->_jinglePeerConnection != nullptr) {
+    self->_jinglePeerConnection->CreateAnswer(self->_createAnswerObserver, nullptr);
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::Undefined());
@@ -285,16 +289,19 @@ NAN_METHOD(PeerConnection::SetLocalDescription) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
-  Local<Object> desc = Local<Object>::Cast(info[0]);
-  String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
-  String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
 
-  std::string type = *_type;
-  std::string sdp = *_sdp;
-  webrtc::SdpParseError error;
-  webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
+  if (self->_jinglePeerConnection != nullptr) {
+    Local<Object> desc = Local<Object>::Cast(info[0]);
+    String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
+    String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
 
-  self->_jinglePeerConnection->SetLocalDescription(self->_setLocalDescriptionObserver, sdi);
+    std::string type = *_type;
+    std::string sdp = *_sdp;
+    webrtc::SdpParseError error;
+    webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
+
+    self->_jinglePeerConnection->SetLocalDescription(self->_setLocalDescriptionObserver, sdi);
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::Undefined());
@@ -304,16 +311,19 @@ NAN_METHOD(PeerConnection::SetRemoteDescription) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
-  Local<Object> desc = Local<Object>::Cast(info[0]);
-  String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
-  String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
 
-  std::string type = *_type;
-  std::string sdp = *_sdp;
-  webrtc::SdpParseError error;
-  webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
+  if (self->_jinglePeerConnection != nullptr) {
+    Local<Object> desc = Local<Object>::Cast(info[0]);
+    String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
+    String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
 
-  self->_jinglePeerConnection->SetRemoteDescription(self->_setRemoteDescriptionObserver, sdi);
+    std::string type = *_type;
+    std::string sdp = *_sdp;
+    webrtc::SdpParseError error;
+    webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
+
+    self->_jinglePeerConnection->SetRemoteDescription(self->_setRemoteDescriptionObserver, sdi);
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::Undefined());
@@ -334,7 +344,7 @@ NAN_METHOD(PeerConnection::AddIceCandidate) {
   webrtc::SdpParseError sdpParseError;
   webrtc::IceCandidateInterface* ci = webrtc::CreateIceCandidate(sdp_mid, sdp_mline_index, candidate, &sdpParseError);
 
-  if (self->_jinglePeerConnection->AddIceCandidate(ci)) {
+  if (self->_jinglePeerConnection != nullptr && self->_jinglePeerConnection->AddIceCandidate(ci)) {
     self->QueueEvent(PeerConnection::ADD_ICE_CANDIDATE_SUCCESS, static_cast<void*>(nullptr));
   } else {
     PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(std::string("Failed to set ICE candidate."));
@@ -349,6 +359,12 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
+
+  if (self->_jinglePeerConnection == nullptr) {
+      info.GetReturnValue().Set(Nan::Undefined());
+      return;
+  }
+
   String::Utf8Value label(info[0]->ToString());
   Handle<Object> dataChannelDict = Handle<Object>::Cast(info[1]);
 
@@ -411,7 +427,12 @@ NAN_METHOD(PeerConnection::GetStats) {
   rtc::scoped_refptr<StatsObserver> statsObserver =
      new rtc::RefCountedObject<StatsObserver>(self, onSuccess);
 
-  if (!self->_jinglePeerConnection->GetStats(statsObserver, nullptr,
+  if (self->_jinglePeerConnection == nullptr) {
+    Local<Value> argv[] = {
+      Nan::New("data channel is closed").ToLocalChecked()
+    };
+    onFailure->Call(1, argv);
+  } else if (!self->_jinglePeerConnection->GetStats(statsObserver, nullptr,
     webrtc::PeerConnectionInterface::kStatsOutputLevelStandard)) {
     // TODO: Include error?
     Local<Value> argv[] = {
@@ -434,7 +455,10 @@ NAN_METHOD(PeerConnection::Close) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
-  self->_jinglePeerConnection->Close();
+
+  if (self->_jinglePeerConnection != nullptr) {
+    self->_jinglePeerConnection->Close();
+  }
 
   self->_jinglePeerConnection = nullptr;
   self->_jinglePeerConnectionFactory = nullptr;
@@ -447,7 +471,11 @@ NAN_GETTER(PeerConnection::GetLocalDescription) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
-  const webrtc::SessionDescriptionInterface* sdi = self->_jinglePeerConnection->local_description();
+  const webrtc::SessionDescriptionInterface* sdi = nullptr;
+  
+  if ( self->_jinglePeerConnection != nullptr) {
+      sdi = self->_jinglePeerConnection->local_description();
+  }
 
   Handle<Value> value;
   if (nullptr == sdi) {
@@ -470,7 +498,11 @@ NAN_GETTER(PeerConnection::GetRemoteDescription) {
   TRACE_CALL;
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
-  const webrtc::SessionDescriptionInterface* sdi = self->_jinglePeerConnection->remote_description();
+  const webrtc::SessionDescriptionInterface* sdi = nullptr;
+  
+  if ( self->_jinglePeerConnection != nullptr) {
+    sdi = self->_jinglePeerConnection->remote_description();
+  }
 
   Handle<Value> value;
   if (nullptr == sdi) {
@@ -494,7 +526,13 @@ NAN_GETTER(PeerConnection::GetSignalingState) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
-  webrtc::PeerConnectionInterface::SignalingState state = self->_jinglePeerConnection->signaling_state();
+  webrtc::PeerConnectionInterface::SignalingState state;
+
+  if (self->_jinglePeerConnection != nullptr) {
+    state = self->_jinglePeerConnection->signaling_state();
+  } else {
+    state = webrtc::PeerConnectionInterface::kClosed;
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New<Number>(state));
@@ -505,7 +543,13 @@ NAN_GETTER(PeerConnection::GetIceConnectionState) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
-  webrtc::PeerConnectionInterface::IceConnectionState state = self->_jinglePeerConnection->ice_connection_state();
+  webrtc::PeerConnectionInterface::IceConnectionState state;
+
+  if (self->_jinglePeerConnection != nullptr) {
+    state = self->_jinglePeerConnection->ice_connection_state();
+  } else {
+    state = webrtc::PeerConnectionInterface::kIceConnectionClosed;
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New<Number>(state));
@@ -516,7 +560,13 @@ NAN_GETTER(PeerConnection::GetIceGatheringState) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
-  webrtc::PeerConnectionInterface::IceGatheringState state = self->_jinglePeerConnection->ice_gathering_state();
+  webrtc::PeerConnectionInterface::IceGatheringState state;
+
+  if (self->_jinglePeerConnection != nullptr) {
+    state = self->_jinglePeerConnection->ice_gathering_state();
+  } else {
+    state = webrtc::PeerConnectionInterface::kIceGatheringComplete;
+  }
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New<Number>(static_cast<uint32_t>(state)));

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -361,8 +361,8 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
   if (self->_jinglePeerConnection == nullptr) {
-      info.GetReturnValue().Set(Nan::Undefined());
-      return;
+    info.GetReturnValue().Set(Nan::Undefined());
+    return;
   }
 
   String::Utf8Value label(info[0]->ToString());
@@ -474,7 +474,7 @@ NAN_GETTER(PeerConnection::GetLocalDescription) {
   const webrtc::SessionDescriptionInterface* sdi = nullptr;
   
   if ( self->_jinglePeerConnection != nullptr) {
-      sdi = self->_jinglePeerConnection->local_description();
+    sdi = self->_jinglePeerConnection->local_description();
   }
 
   Handle<Value> value;

--- a/test/connect.js
+++ b/test/connect.js
@@ -244,9 +244,25 @@ test('getStats', function(t) {
 });
 
 test('close the connections', function(t) {
-  t.plan(1);
+  t.plan(3);
+
   peers[0].close();
   peers[1].close();
+
+  // make sure nothing crashes after connection is closed and _jinglePeerConnection is null
+  for (var i = 0; i < 2; i++) {
+    peers[i].createOffer();
+    peers[i].createAnswer();
+    peers[i].setLocalDescription({}, function() {}, function(){});
+    peers[i].setRemoteDescription({}, function() {}, function(){});
+    peers[i].addIceCandidate({}, function() {}, function(){});
+    peers[i].createDataChannel('test');
+    peers[i].getStats(function(){}, function(err){
+        t.ok(err);
+    });
+    peers[i].close();
+  }
+
   t.pass('closed connections');
 
   peers = [];


### PR DESCRIPTION
Currently, the `jinglePeerConnection` and `jinglePeerConnectionFactory` pointers are being nulled only in the destructor; therefore, the threads associated to the peer connection keep running and consuming CPU until the garbage collector kicks in, which can take a while in some cases and can be an issue when handling many connections.

This PR addresses the issue (#289) by also nulling those pointers in the `Close` method. The CPU usage associated with the connection should drop instantly.

The PR also introduces two minor changes to the API:
- `createIceCandidate` will return `undefined` if the connection is already closed when the method is called
- if the connection is already closed when `getStats` is called, the `onFailure` callback will return a `data channel is closed` message.

I've been testing on Ubuntu 14.04 (32 and 64 bit) and on Debian Wheezy (32 bit), node versions 4.5 and 6.5.
