### PR TITLE
Update to webrtc v56

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -2,7 +2,6 @@
 #include "v8.h"
 
 #include "webrtc/api/peerconnectioninterface.h"
-#include "webrtc/base/scoped_ptr.h"
 #include "webrtc/base/scoped_ref_ptr.h"
 #include "webrtc/base/ssladapter.h"
 #include "webrtc/base/thread.h"

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -247,14 +247,14 @@ NAN_METHOD(DataChannel::Send) {
     }
 
     v8::ArrayBuffer::Contents content = arraybuffer->Externalize();
-    rtc::Buffer buffer(static_cast<char*>(content.Data()), content.ByteLength());
+    rtc::CopyOnWriteBuffer buffer(static_cast<char*>(content.Data()),content.ByteLength());
 
 #else
     Local<Object> arraybuffer = Local<Object>::Cast(info[0]);
     void* data = arraybuffer->GetIndexedPropertiesExternalArrayData();
     uint32_t data_len = arraybuffer->GetIndexedPropertiesExternalArrayDataLength();
 
-    rtc::Buffer buffer(data, data_len);
+    rtc::CopyOnWriteBuffer buffer(static_cast<char*>(content.Data()),content.ByteLength());
 
 #endif
 


### PR DESCRIPTION
Makes node-webrtc compile properly with markandrus/build-webrtc#2. But actually running it fails with this error:

```
> node examples/ping-pong-test.js                                                                          (webrtc-56)
module.js:598
  return process.dlopen(module, path._makeLong(filename));
                 ^

Error: /home/getkey/devel/node-webrtc-next/build/wrtc/v0.0.62/Release/node-v51-linux-x64/wrtc.node: undefined symbol: _ZN3rtc6Thread5ClearEPNS_14MessageHandlerEjPSt4listINS_7MessageESaIS4_EE
    at Object.Module._extensions..node (module.js:598:18)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/home/getkey/devel/node-webrtc-next/getkey/devel/node-webrtc-next/lib/peerconnection.js:6:15)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
```

The undefined symbol seems to be here though:

```sh
> nm -C build/wrtc/v0.0.62/Release/node-v51-linux-x64/wrtc.node | awk '/Thread/ && /Clear/'
                 U rtc::Thread::Clear(rtc::MessageHandler*, unsigned int, std::list<rtc::Message, std::allocator<rtc::Message> >*)

```

I'm not really sure how to fix this.