### PR TITLE
Fixed 'Failed to set ICE candidate.' Error revealed by running in node 8

### DIFF
--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -182,7 +182,7 @@ wss.on('connection', function(ws)
       if(remoteReceived)
       {
         if(data.sdp.candidate) {
-          pc.addIceCandidate(new webrtc.RTCIceCandidate(data.sdp.candidate));
+          pc.addIceCandidate(new webrtc.RTCIceCandidate(data.sdp));
         }
       } else
       {


### PR DESCRIPTION
Node 8 complains about an unhandled promise. (node:39275) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Failed to set ICE candidate.