### PR TITLE
Fix segfaults in RTCDataChannel and RTCPeerConnection by not freeing objects until destruction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Arno Klein <klaronix@aklein.net>
 Manu Raghavan <manu@voxology.co>
 Ross Kukulinski <ross@getyodlr.com>
 Jeppe Ryskov Larsen <jeppe@bjergsted.dk>
+Nazar Mokrynskyi <nazar@mokrynskyi.com>

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -298,13 +298,9 @@ NAN_GETTER(DataChannel::GetBufferedAmount) {
 
   DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.Holder());
 
-  uint64_t buffered_amount;
-
-  if (self->_jingleDataChannel != nullptr) {
-    buffered_amount = self->_jingleDataChannel->buffered_amount();
-  } else {
-    buffered_amount = 0;
-  }
+  uint64_t buffered_amount = self->_jingleDataChannel != nullptr
+    ? self->_jingleDataChannel->buffered_amount()
+    : 0;
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New<Number>(buffered_amount));
@@ -315,13 +311,9 @@ NAN_GETTER(DataChannel::GetLabel) {
 
   DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.Holder());
 
-  std::string label;
-
-  if (self->_jingleDataChannel != nullptr) {
-    label = self->_jingleDataChannel->label();
-  } else {
-    label = "";
-  }
+  std::string label = self->_jingleDataChannel != nullptr
+    ? self->_jingleDataChannel->label()
+    : "";
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New(label).ToLocalChecked());
@@ -332,13 +324,9 @@ NAN_GETTER(DataChannel::GetReadyState) {
 
   DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.Holder());
 
-  webrtc::DataChannelInterface::DataState state;
-
-  if (self->_jingleDataChannel != nullptr) {
-    state = self->_jingleDataChannel->state();
-  } else {
-    state = webrtc::DataChannelInterface::kClosed;
-  }
+  webrtc::DataChannelInterface::DataState state = self->_jingleDataChannel != nullptr
+    ? self->_jingleDataChannel->state()
+    : webrtc::DataChannelInterface::kClosed;
 
   TRACE_END;
   info.GetReturnValue().Set(Nan::New<Number>(static_cast<uint32_t>(state)));

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -251,14 +251,14 @@ NAN_METHOD(PeerConnection::New) {
   }
 
   webrtc::PeerConnectionInterface::IceServers iceServerList;
-  
+
   // Check if we have a configuration object
   if (info[0]->IsObject()) {
     const Local<Object> obj = info[0]->ToObject();
 
     // Extract keys into array for iteration
     const Local<Array> props = obj->GetPropertyNames();
-    
+
     // Iterate all of the top-level config keys
     for (uint32_t i = 0; i < props->Length(); i++) {
       // Get the key and value for this particular config field
@@ -279,7 +279,7 @@ NAN_METHOD(PeerConnection::New) {
 
             const Local<Object> iceServerObj = iceServers->Get(j)->ToObject();
             webrtc::PeerConnectionInterface::IceServer iceServer;
-            
+
             const Local<Array> iceProps = iceServerObj->GetPropertyNames();
 
             // Now we have an iceserver object in iceServerObj - Lets iterate all of its fields
@@ -426,7 +426,7 @@ NAN_METHOD(PeerConnection::AddIceCandidate) {
     self->QueueEvent(PeerConnection::ADD_ICE_CANDIDATE_SUCCESS, static_cast<void*>(nullptr));
   } else {
     std::string error = std::string("Failed to set ICE candidate");
-    if( !self->_jinglePeerConnection ) {
+    if(self->_jinglePeerConnection == nullptr) {
       error += ", no jingle peer connection";
     } else if( sdpParseError.description.length() ) {
       error += std::string(", parse error: ") + sdpParseError.description;
@@ -557,8 +557,8 @@ NAN_GETTER(PeerConnection::GetLocalDescription) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
   const webrtc::SessionDescriptionInterface* sdi = nullptr;
-  
-  if ( self->_jinglePeerConnection != nullptr) {
+
+  if (self->_jinglePeerConnection != nullptr) {
     sdi = self->_jinglePeerConnection->local_description();
   }
 
@@ -584,8 +584,8 @@ NAN_GETTER(PeerConnection::GetRemoteDescription) {
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
   const webrtc::SessionDescriptionInterface* sdi = nullptr;
-  
-  if ( self->_jinglePeerConnection != nullptr) {
+
+  if (self->_jinglePeerConnection != nullptr) {
     sdi = self->_jinglePeerConnection->remote_description();
   }
 

--- a/test/closing-peer-connection.js
+++ b/test/closing-peer-connection.js
@@ -1,0 +1,48 @@
+'use strict';
+var test = require('tape');
+var wrtc = require('..');
+
+var RTCPeerConnection = wrtc.RTCPeerConnection;
+
+test('make sure channel is available after after connection is closed on the other side', function (t) {
+	t.plan(2);
+
+	var peer1       = new RTCPeerConnection({iceServers : []});
+	var peer2       = new RTCPeerConnection({iceServers : []});
+	var channel1    = peer1.createDataChannel('data', {negotiated : true, id : 0});
+	var channel2    = peer2.createDataChannel('data2', {negotiated : true, id : 0});
+	var waiting_for = 2;
+
+	function ready () {
+		--waiting_for;
+		if (!waiting_for) {
+			channel2.close();
+			t.equal(channel2.readyState, 'closed', 'can still check ready state after closing');
+			peer2.close();
+			setTimeout(function () {
+				channel1.send('Hello');
+				channel1.close();
+				peer1.close();
+				t.equal(channel1.readyState, 'closed', 'channel on the other side is also closed, but we did not crash');
+			}, 100);
+		}
+	}
+
+	channel1.onopen = ready;
+	channel2.onopen = ready;
+
+	peer1.createOffer()
+		.then(function (offer) {
+			return peer1.setLocalDescription(offer);
+		})
+		.then(function () {
+			peer2.setRemoteDescription(peer1.localDescription);
+			return peer2.createAnswer();
+		})
+		.then(function (answer) {
+			return peer2.setLocalDescription(answer);
+		})
+		.then(function () {
+			peer1.setRemoteDescription(peer2.localDescription);
+		});
+});


### PR DESCRIPTION
This fixes #236 and fixes #325.

Hopefully, this can be merged and released soon.

P.S. I'm not a C/C++ developer even remotely and might have done something horribly wrong, but it seems to work correctly.