### PR TITLE
Destroy mutexes in destructor

### DIFF
--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -39,6 +39,7 @@ DataChannelObserver::DataChannelObserver(rtc::scoped_refptr<webrtc::DataChannelI
 
 DataChannelObserver::~DataChannelObserver() {
   _jingleDataChannel = nullptr;
+  uv_mutex_destroy(&lock);
 }
 
 void DataChannelObserver::OnStateChange() {

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -73,6 +73,7 @@ PeerConnection::~PeerConnection() {
   TRACE_CALL;
   _jinglePeerConnection = nullptr;
   _jinglePeerConnectionFactory = nullptr;
+  uv_mutex_destroy(&lock);
   TRACE_END;
 }
 


### PR DESCRIPTION
I have no idea how to use libuv, but from usage examples I found it seems that `uv_mutex_destroy` is needed.