### PR TITLE
Ref() and Unref() ObjectWrap instances w/ EventLoops

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -18,7 +18,6 @@ function RTCPeerConnection(configuration, constraints) {
   var remoteType = null;
   var queue = [];
   var pending = null;
-  var dataChannels = {};  // open data channels, indexed by label
 
   EventTarget.call(this);
 
@@ -85,17 +84,7 @@ function RTCPeerConnection(configuration, constraints) {
     self.dispatchEvent(new RTCPeerConnectionIceEvent('icecandidate', { candidate: icecandidate }));
   };
 
-  pc.onsignalingstatechange = function onsignalingstatechange(state) {
-    var stateString = self.RTCSignalingStates[state];
-
-    if ('closed' === stateString) {
-      Object.keys(dataChannels).forEach(function(label) {
-        dataChannels[label].shutdown();
-
-        delete dataChannels[label];
-      });
-    }
-
+  pc.onsignalingstatechange = function onsignalingstatechange() {
     self.dispatchEvent({ type: 'signalingstatechange' });
   };
 
@@ -115,8 +104,6 @@ function RTCPeerConnection(configuration, constraints) {
   // [ToDo] onnegotiationneeded
 
   pc.ondatachannel = function ondatachannel(internalDC) {
-    dataChannels[internalDC.label] = internalDC;
-
     var dc = new RTCDataChannel(internalDC);
 
     self.dispatchEvent(new RTCDataChannelEvent('datachannel', { channel: dc }));
@@ -365,7 +352,6 @@ function RTCPeerConnection(configuration, constraints) {
     // channel will be undefined if dataChannel was closed before calling this function
     // (see peerconnection.cc)
     if (channel) {
-        dataChannels[label] = channel;
         return new RTCDataChannel(channel);
     }
   };

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -293,18 +293,6 @@ NAN_METHOD(DataChannel::Close) {
   return;
 }
 
-NAN_METHOD(DataChannel::Shutdown) {
-  TRACE_CALL;
-
-  DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.This());
-  if (!uv_is_closing(reinterpret_cast<uv_handle_t*>(&self->async))) {
-    uv_close(reinterpret_cast<uv_handle_t*>(&self->async), nullptr);
-  }
-
-  TRACE_END;
-  return;
-}
-
 NAN_GETTER(DataChannel::GetBufferedAmount) {
   TRACE_CALL;
 
@@ -372,7 +360,6 @@ void DataChannel::Init(Handle<Object> exports) {
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   Nan::SetPrototypeMethod(tpl, "close", Close);
-  Nan::SetPrototypeMethod(tpl, "shutdown", Shutdown);
   Nan::SetPrototypeMethod(tpl, "send", Send);
 
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("bufferedAmount").ToLocalChecked(), GetBufferedAmount, ReadOnly);

--- a/src/datachannel.h
+++ b/src/datachannel.h
@@ -88,7 +88,6 @@ class DataChannel
 
   static NAN_METHOD(Send);
   static NAN_METHOD(Close);
-  static NAN_METHOD(Shutdown);
 
   static NAN_GETTER(GetBufferedAmount);
   static NAN_GETTER(GetLabel);


### PR DESCRIPTION
@nazar-pc please take a look. I was seeing segfaults when accessing `self->handle()` in `Run`. Both node_webrtc::PeerConnection and node_webrtc::DataChannel run an event loop (see `Run`). I think the issue is that these objects could be freed despite the fact that `Run` was still running and trying to access the instances via `async`. [Docs for nan::ObjectWrap](https://github.com/nodejs/nan/blob/master/doc/object_wrappers.md) mention `Ref()` and `Unref()` methods to be used if an object is part of an event loop. So the new pattern here is to `Ref()` in `New` and `Unref()` at the end of `Run` when `do_shutdown` is `true`.

Edit: I ran a tweaked version locally where I logged in the PeerConnection and DataChannel destructors; I see PeerConnections destruct, but rarely DataChannels, so there may be a bug causing DataChannels to leak. Should address before merge...

Edit 2: I believe the DataChannels aren't freed because they are retained in an object inside `lib/peerconnection.js`. Removing this object (I cannot see why it is necessary) allows them to be freed.