### PR TITLE
Fix segfault on datachannel close

### DIFF
--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -30,7 +30,7 @@ Nan::Persistent<Function> DataChannel::ArrayBufferConstructor;
 #endif
 
 DataChannelObserver::DataChannelObserver(std::shared_ptr<node_webrtc::PeerConnectionFactory> factory,
-                                         rtc::scoped_refptr<webrtc::DataChannelInterface> jingleDataChannel) {
+    rtc::scoped_refptr<webrtc::DataChannelInterface> jingleDataChannel) {
   TRACE_CALL;
   uv_mutex_init(&lock);
   _factory = factory;

--- a/src/datachannel.h
+++ b/src/datachannel.h
@@ -127,7 +127,7 @@ class DataChannelObserver
   friend class node_webrtc::DataChannel;
  public:
   explicit DataChannelObserver(std::shared_ptr<node_webrtc::PeerConnectionFactory> factory,
-                               rtc::scoped_refptr<webrtc::DataChannelInterface> jingleDataChannel);
+      rtc::scoped_refptr<webrtc::DataChannelInterface> jingleDataChannel);
   virtual ~DataChannelObserver();
 
   virtual void OnStateChange();

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -226,7 +226,7 @@ void PeerConnection::OnIceCandidate(const webrtc::IceCandidateInterface* candida
   TRACE_END;
 }
 
-void PeerConnection::OnDataChannel(webrtc::DataChannelInterface* jingle_data_channel) {
+void PeerConnection::OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> jingle_data_channel) {
   TRACE_CALL;
   DataChannelObserver* observer = new DataChannelObserver(jingle_data_channel);
   PeerConnection::DataChannelEvent* data = new PeerConnection::DataChannelEvent(observer);

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -228,7 +228,7 @@ void PeerConnection::OnIceCandidate(const webrtc::IceCandidateInterface* candida
 
 void PeerConnection::OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> jingle_data_channel) {
   TRACE_CALL;
-  DataChannelObserver* observer = new DataChannelObserver(jingle_data_channel);
+  DataChannelObserver* observer = new DataChannelObserver(_factory, jingle_data_channel);
   PeerConnection::DataChannelEvent* data = new PeerConnection::DataChannelEvent(observer);
   QueueEvent(PeerConnection::NOTIFY_DATA_CHANNEL, static_cast<void*>(data));
   TRACE_END;
@@ -496,7 +496,7 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
   }
 
   rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_interface = self->_jinglePeerConnection->CreateDataChannel(*label, &dataChannelInit);
-  DataChannelObserver* observer = new DataChannelObserver(data_channel_interface);
+  DataChannelObserver* observer = new DataChannelObserver(self->_factory, data_channel_interface);
 
   Local<Value> cargv[1];
   cargv[0] = Nan::New<External>(static_cast<void*>(observer));

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -137,7 +137,7 @@ class PeerConnection
   virtual void OnIceCandidate(const webrtc::IceCandidateInterface* candidate);
   virtual void OnRenegotiationNeeded();
 
-  virtual void OnDataChannel(webrtc::DataChannelInterface* data_channel);
+  virtual void OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel);
 
   virtual void OnAddStream(webrtc::MediaStreamInterface* stream);
   virtual void OnRemoveStream(webrtc::MediaStreamInterface* stream);

--- a/src/peerconnectionfactory.cc
+++ b/src/peerconnectionfactory.cc
@@ -31,6 +31,8 @@ uv_mutex_t PeerConnectionFactory::_lock;
 int PeerConnectionFactory::_references = 0;
 
 PeerConnectionFactory::PeerConnectionFactory(rtc::scoped_refptr<webrtc::AudioDeviceModule> audioDeviceModule) {
+  TRACE_CALL;
+
   bool result;
 
   _workerThread = std::unique_ptr<rtc::Thread>(new rtc::Thread());
@@ -48,9 +50,13 @@ PeerConnectionFactory::PeerConnectionFactory(rtc::scoped_refptr<webrtc::AudioDev
   _factory = webrtc::CreatePeerConnectionFactory(_workerThread.get(), _signalingThread.get(), audioDeviceModule,
           nullptr, nullptr);
   assert(_factory);
+
+  TRACE_END;
 }
 
 PeerConnectionFactory::~PeerConnectionFactory() {
+  TRACE_CALL;
+
   _factory = nullptr;
 
   _workerThread->Stop();
@@ -58,6 +64,8 @@ PeerConnectionFactory::~PeerConnectionFactory() {
 
   _workerThread = nullptr;
   _signalingThread = nullptr;
+
+  TRACE_END;
 }
 
 NAN_METHOD(PeerConnectionFactory::New) {

--- a/test/all.js
+++ b/test/all.js
@@ -6,3 +6,5 @@ require('./connect');
 require('./iceservers');
 // require('./bwtest').tape();
 // require('./multiconnect');
+require('./closing-peer-connection');
+require('./closing-data-channel');

--- a/test/closing-data-channel.js
+++ b/test/closing-data-channel.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const test = require('tape');
+const { RTCPeerConnection } = require('..');
+
+test('make sure closing an RTCDataChannel after an RTCPeerConnection has been garbage collected doesn\'t segfault', t => {
+  const dc = (() => {
+    const pc = new RTCPeerConnection();
+    const dc = pc.createDataChannel();
+    pc.close();
+    return dc;
+  })();
+
+  dc.close();
+  t.end();
+});

--- a/test/closing-data-channel.js
+++ b/test/closing-data-channel.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const test = require('tape');
-const { RTCPeerConnection } = require('..');
+var test = require('tape');
+var RTCPeerConnection = require('..').RTCPeerConnection;
 
-test('make sure closing an RTCDataChannel after an RTCPeerConnection has been garbage collected doesn\'t segfault', t => {
-  const dc = (() => {
-    const pc = new RTCPeerConnection();
-    const dc = pc.createDataChannel();
+test('make sure closing an RTCDataChannel after an RTCPeerConnection has been garbage collected doesn\'t segfault', function(t) {
+  var dc = (function() {
+    var pc = new RTCPeerConnection();
+    var dc = pc.createDataChannel();
     pc.close();
     return dc;
   })();


### PR DESCRIPTION
@nazar-pc this should fix #360. The issue is that `node_webrtc::PeerConnection` was the only thing holding a reference to `node_webrtc::PeerConnectionFactory`. Once the `RTCPeerConnection` got garbage collected, `node_webrtc::PeerConnection::~PeerConnection` gets invoked, `Release`ing the `node_webrtc::PeerConnectionFactory`. This `Stop`s and frees the `rtc::Thread`s in use, causing the segfault when the `RTCDataChannel` is `close`d.

The solution is to thread the `node_webrtc::PeerConnectionFactory` along to child objects like `node_webrtc::DataChannel` (and any eventual `node_webrtc::MediaStreamTrack`s we might add—cc @thedracle). Then, `node_webrtc::PeerConnection` can still `Release` the `node_webrtc::PeerConnectionFactory`, but it won't get garbage collected until the objects that depend on it are garbage collected.

There were some conditions I tested manually with the code with `TRACING` defined (namely, that destructors for `node_webrtc::PeerConnectionFactory` and `node_webrtc::DataChannel` did fire, and in the right order). We want to make sure these never leak, so we should consider landing some unit tests in the future that check the `TRACING` output to ensure they fire (perhaps also using Node's `--expose-gc` flag and the `gc` function). Until then, I've added the previously failing test, `test/closing-data-channel.js`.