### PR TITLE
Use unprefixed APIs

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,5 @@
 'use strict';
 
-exports.RTCIceCandidate = window.mozRTCIceCandidate || window.webkitRTCIceCandidate || window.RTCIceCandidate;
-exports.RTCPeerConnection = window.mozRTCPeerConnection || window.webkitRTCPeerConnection || window.RTCPeerConnection;
-exports.RTCSessionDescription = window.mozRTCSessionDescription || window.webkitRTCSessionDescription || window.RTCSessionDescription;
+exports.RTCIceCandidate = window.RTCIceCandidate;
+exports.RTCPeerConnection = window.RTCPeerConnection;
+exports.RTCSessionDescription = window.RTCSessionDescription;


### PR DESCRIPTION
I think it is time to remove usage of old prefixed APIs (Firefox Nightly already complains that they are deprecated).

Firefox supports unprefixed APIs since 44 (released on January 27, 2016), see https://caniuse.com/#search=RTCPeerConnection
Chrome supports unprefixed APIs since 56 (released on January 25, 2017), see https://www.chromestatus.com/feature/5312661013135360

I suspect other Blink-based browsers should also support unprefixed versions for a while now.