### PR TITLE
Conversions

### DIFF
--- a/examples/bridge.js
+++ b/examples/bridge.js
@@ -136,7 +136,7 @@ wss.on('connection', function(ws) {
       remoteReceived = false;
 
       pc = new webrtc.RTCPeerConnection({
-        iceServers: [{ url: 'stun:stun.l.google.com:19302' }]
+        iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
       }, {
         optional: [{ DtlsSrtpKeyAgreement: false }]
       });

--- a/examples/peer.js
+++ b/examples/peer.js
@@ -47,7 +47,7 @@ test('Bridge Example', function(t) {
 
   var ws = null;
   var pc = new RTCPeerConnection({
-    iceServers: [{ url: 'stun:stun.l.google.com:19302' }]
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
   }, {
     optional: []
   });

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -14,8 +14,6 @@ var RTCStatsResponse = require('./rtcstatsresponse');
 function RTCPeerConnection(configuration, constraints) {
   var self = this;
   var pc = new _webrtc.PeerConnection(configuration, constraints);
-  var localType = null;
-  var remoteType = null;
   var queue = [];
   var pending = null;
 
@@ -92,11 +90,11 @@ function RTCPeerConnection(configuration, constraints) {
     self.dispatchEvent({ type: 'iceconnectionstatechange' });
   };
 
-  pc.onicegatheringstatechange = function onicegatheringstatechange(state) {
+  pc.onicegatheringstatechange = function onicegatheringstatechange() {
     self.dispatchEvent({ type: 'icegatheringstatechange' });
 
     // if we have completed gathering candidates, trigger a null candidate event
-    if (self.RTCIceGatheringStates[state] === 'complete') {
+    if (self.iceGatheringState === 'complete') {
       self.dispatchEvent(new RTCPeerConnectionIceEvent('icecandidate', { candidate: null }));
     }
   };
@@ -116,26 +114,21 @@ function RTCPeerConnection(configuration, constraints) {
   Object.defineProperties(this, {
     localDescription: {
       get: function getLocalDescription() {
-        var sdp = pc.localDescription;
-        if (!sdp) {
-          return null;
-        }
-        return new RTCSessionDescription({ type: localType, sdp: sdp });
+        return pc.localDescription
+          ? new RTCSessionDescription(pc.localDescription)
+          : null;
       }
     },
     remoteDescription: {
       get: function getRemoteDescription() {
-        var sdp = pc.remoteDescription;
-        if (!sdp) {
-          return null;
-        }
-        return new RTCSessionDescription({ type: remoteType, sdp: sdp });
+        return pc.remoteDescription
+          ? new RTCSessionDescription(pc.remoteDescription)
+          : null;
       }
     },
     signalingState: {
       get: function getSignalingState() {
-        var state = pc.signalingState;
-        return this.RTCSignalingStates[state];
+        return pc.signalingState;
       }
     },
     readyState: {
@@ -145,14 +138,12 @@ function RTCPeerConnection(configuration, constraints) {
     },
     iceGatheringState: {
       get: function getIceGatheringState() {
-        var state = pc.iceGatheringState;
-        return this.RTCIceGatheringStates[state];
+        return pc.iceGatheringState;
       }
     },
     iceConnectionState: {
       get: function getIceConnectionState() {
-        var state = pc.iceConnectionState;
-        return this.RTCIceConnectionStates[state];
+        return pc.iceConnectionState;
       }
     }
   });
@@ -225,8 +216,6 @@ function RTCPeerConnection(configuration, constraints) {
   // eslint-disable-next-line consistent-return
   this.setLocalDescription = function setLocalDescription() {
     function call(description, successCallback, failureCallback) {
-      localType = description.type;
-
       queueOrRun({
         func: 'setLocalDescription',
         args: [description],
@@ -264,8 +253,6 @@ function RTCPeerConnection(configuration, constraints) {
   // eslint-disable-next-line consistent-return
   this.setRemoteDescription = function setRemoteDescription() {
     function call(description, successCallback, failureCallback) {
-      remoteType = description.type;
-
       queueOrRun({
         func: 'setRemoteDescription',
         args: [description],
@@ -369,31 +356,5 @@ function RTCPeerConnection(configuration, constraints) {
     });
   };
 }
-
-RTCPeerConnection.prototype.RTCIceConnectionStates = [
-  'new',
-  'checking',
-  'connected',
-  'completed',
-  'failed',
-  'disconnected',
-  'closed'
-];
-
-RTCPeerConnection.prototype.RTCIceGatheringStates = [
-  'new',
-  'gathering',
-  'complete'
-];
-
-RTCPeerConnection.prototype.RTCSignalingStates = [
-  'stable',
-  'have-local-offer',
-  'have-local-pranswer',
-  'have-remote-offer',
-  'have-remote-pranswer',
-  'closed'
-];
-
 
 module.exports = RTCPeerConnection;

--- a/src/converters.h
+++ b/src/converters.h
@@ -1,0 +1,73 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines conversion functions and short-hand for converting between
+ * different types. Conversions can fail, hence we use Validation.
+ */
+
+#ifndef SRC_CONVERTERS_H_
+#define SRC_CONVERTERS_H_
+
+#include "src/functional/curry.h"
+#include "src/functional/either.h"
+#include "src/functional/maybe.h"
+#include "src/functional/operators.h"
+#include "src/functional/validation.h"
+
+namespace node_webrtc {
+
+/**
+ * A Converter converts values from some "source" type S to values of some
+ * "target" type T.
+ * @tparam S the source type
+ * @tparam T the target type
+ */
+template <typename S, typename T>
+struct Converter {};
+
+/**
+ * From is short-hand for invoking a particular Converter.
+ * @tparam T the target type
+ * @tparam S the source type
+ * @param s the source value
+ * @return the target value
+ */
+template <typename T, typename S>
+static Validation<T> From(const S s) {
+  return Converter<S, T>::Convert(s);
+}
+
+/**
+ * There is an "identity" Converter between values of the same type T.
+ * @tparam T the source and target type
+ */
+template <typename T>
+struct Converter<T, T> {
+  static Validation<T> Convert(const T t) {
+    return Validation<T>(t);
+  }
+};
+
+/**
+ * There is a Converter that tries first one conversion, then another.
+ * @tparam S the source type
+ * @tparam L a target type L
+ * @tparam R a target type R
+ */
+template <typename S, typename L, typename R>
+struct Converter<S, Either<L, R>> {
+  static Validation<Either<L, R>> Convert(const S s) {
+    return From<L>(s).Map(&Either<L, R>::Left)
+        | (From<R>(s).Map(&Either<L, R>::Right));
+  }
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_CONVERTERS_H_

--- a/src/converters/arguments.h
+++ b/src/converters/arguments.h
@@ -1,0 +1,64 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines functions for decomposing method arguments.
+ */
+
+#ifndef SRC_CONVERTERS_ARGUMENTS_H_
+#define SRC_CONVERTERS_ARGUMENTS_H_
+
+#include <tuple>
+
+#include "nan.h"
+
+#include "src/converters.h"
+#include "src/functional/curry.h"
+#include "src/functional/validation.h"
+
+namespace node_webrtc {
+
+template <typename A>
+struct Converter<Nan::NAN_METHOD_ARGS_TYPE, A> {
+  static Validation<A> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
+    return From<A>(info[0]);
+  }
+};
+
+template <typename A, typename B>
+static std::tuple<A, B> Make2Tuple(A a, B b) {
+  return std::make_tuple(a, b);
+}
+
+template <typename A, typename B>
+struct Converter<Nan::NAN_METHOD_ARGS_TYPE, std::tuple<A, B>> {
+  static Validation<std::tuple<A, B>> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
+    return curry(Make2Tuple<A, B>)
+        % From<A>(info[0])
+        * From<B>(info[1]);
+  }
+};
+
+template <typename A, typename B, typename C>
+static std::tuple<A, B> Make3Tuple(A a, B b, C c) {
+  return std::make_tuple(a, b, c);
+}
+
+template <typename A, typename B, typename C>
+struct Converter<Nan::NAN_METHOD_ARGS_TYPE, std::tuple<A, B, C>> {
+  static Validation<std::tuple<A, B, C>> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
+    return curry(Make3Tuple<A, B, C>)
+        % From<A>(info[0])
+        * From<B>(info[1])
+        * From<C>(info[2]);
+  }
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_CONVERTERS_ARGUMENTS_H_

--- a/src/converters/object.h
+++ b/src/converters/object.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines functions for decomposing v8::Objects.
+ */
+
+#ifndef SRC_CONVERTERS_OBJECT_H_
+#define SRC_CONVERTERS_OBJECT_H_
+
+#include "nan.h"
+
+#include "src/converters.h"
+#include "src/functional/validation.h"
+
+namespace node_webrtc {
+
+template <typename T>
+static Validation<T> GetRequired(const v8::Local<v8::Object> object, const std::string& property) {
+  return From<T>(object->Get(Nan::New(property).ToLocalChecked()));
+}
+
+template <typename T>
+static Validation<Maybe<T>> GetOptional(const v8::Local<v8::Object> object, const std::string& property) {
+  auto value = object->Get(Nan::New(property).ToLocalChecked());
+  if (value->IsUndefined()) {
+    return Validation<Maybe<T>>::Valid(Maybe<T>::Nothing());
+  }
+  return From<T>(value).Map(&Maybe<T>::Just);
+}
+
+template <typename T>
+static Validation<T> GetOptional(
+    const v8::Local<v8::Object> object,
+    const std::string& property,
+    T default_value) {
+  return GetOptional<T>(object, property).Map(
+      [default_value](const Maybe<T> maybeT) { return maybeT.FromMaybe(default_value); });
+}
+
+}  // namespace node_webrtc
+
+#endif  // SRC_CONVERTERS_OBJECT_H_

--- a/src/converters/v8.h
+++ b/src/converters/v8.h
@@ -1,0 +1,136 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines conversion functions between native and v8 data types.
+ */
+
+#ifndef SRC_CONVERTERS_V8_H_
+#define SRC_CONVERTERS_V8_H_
+
+#include "nan.h"
+
+#include "src/converters.h"
+#include "src/functional/validation.h"
+
+namespace node_webrtc {
+
+// TODO(mroberts): The following could probably all be moved into a v8.cc file.
+
+template <typename T>
+struct Converter<v8::Local<v8::Value>, Maybe<T>> {
+  static Validation<Maybe<T>> Convert(const v8::Local<v8::Value> value) {
+    if (value.IsEmpty() || value->IsUndefined()) {
+      return Validation<Maybe<T>>::Valid(Maybe<T>::Nothing());
+    }
+    return From<T>(value).Map(&Maybe<T>::Just);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, bool> {
+  static Validation<bool> Convert(const v8::Local<v8::Value> value) {
+    auto maybeBoolean = Nan::To<v8::Boolean>(value);
+    if (maybeBoolean.IsEmpty()) {
+      return Validation<bool>::Invalid("Expected a bool");
+    }
+    auto boolean = (*maybeBoolean.ToLocalChecked())->Value();
+    return Validation<bool>::Valid(boolean);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, int32_t> {
+  static Validation<int32_t> Convert(const v8::Local<v8::Value> value) {
+    auto maybeInt32 = Nan::To<v8::Int32>(value);
+    if (maybeInt32.IsEmpty()) {
+      return Validation<int32_t>::Invalid("Expected a 32-bit integer");
+    }
+    auto int32 = (*maybeInt32.ToLocalChecked())->Value();
+    return Validation<int32_t>::Valid(int32);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, int64_t> {
+  static Validation<int64_t> Convert(const v8::Local<v8::Value> value) {
+    auto maybeInteger = Nan::To<v8::Integer>(value);
+    if (maybeInteger.IsEmpty()) {
+      return Validation<int64_t>::Invalid("Expected a 64-bit integer");
+    }
+    auto integer = (*maybeInteger.ToLocalChecked())->Value();
+    return Validation<int64_t>::Valid(integer);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, double> {
+  static Validation<double> Convert(const v8::Local<v8::Value> value) {
+    auto maybeNumber = Nan::To<v8::Number>(value);
+    if (maybeNumber.IsEmpty()) {
+      return Validation<double>::Invalid("Expected a double");
+    }
+    auto number = (*maybeNumber.ToLocalChecked())->Value();
+    return Validation<double>::Valid(number);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, std::string> {
+  static Validation<std::string> Convert(const v8::Local<v8::Value> value) {
+    if (!value->IsString()) {
+      return Validation<std::string>::Invalid("Expected a string");
+    }
+    auto string = std::string(*v8::String::Utf8Value(Nan::To<v8::String>(value).ToLocalChecked()));
+    return Validation<std::string>::Valid(string);
+  }
+};
+
+template <typename T>
+struct Converter<v8::Local<v8::Value>, std::vector<T>> {
+  static Validation<std::vector<T>> Convert(const v8::Local<v8::Value> value) {
+    if (!value->IsArray()) {
+      return Validation<std::vector<T>>::Invalid("Expected an array");
+    }
+    auto array = v8::Local<v8::Array>::Cast(value);
+    auto validated = std::vector<Validation<T>>();
+    for (uint32_t i = 0; i < array->Length(); i++) {
+      validated.push_back(From<T>(array->Get(i)));
+    }
+    return Validation<T>::Sequence(validated);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, uint32_t> {
+  static Validation<uint32_t> Convert(const v8::Local<v8::Value> value) {
+    auto maybeUint32 = Nan::To<v8::Uint32>(value);
+    if (maybeUint32.IsEmpty()) {
+      return Validation<uint32_t>::Invalid("Expected a 32-bit unsigned integer");
+    }
+    auto uint32 = (*maybeUint32.ToLocalChecked())->Value();
+    return Validation<uint32_t>::Valid(uint32);
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, v8::Local<v8::Object>> {
+  static Validation<v8::Local<v8::Object>> Convert(const v8::Local<v8::Value> value) {
+    Nan::EscapableHandleScope scope;
+    auto maybeObject = Nan::To<v8::Object>(value);
+    if (maybeObject.IsEmpty()) {
+      return Validation<v8::Local<v8::Object>>::Invalid("Expected an object");
+    }
+    auto object = maybeObject.ToLocalChecked();
+    return Validation<v8::Local<v8::Object>>::Valid(scope.Escape(object));
+  }
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_CONVERTERS_V8_H_

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -1,0 +1,342 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "src/converters/webrtc.h"
+
+#include "src/converters/object.h"
+
+using node_webrtc::Converter;
+using node_webrtc::Either;
+using node_webrtc::From;
+using node_webrtc::GetOptional;
+using node_webrtc::GetRequired;
+using node_webrtc::Maybe;
+using node_webrtc::RTCAnswerOptions;
+using node_webrtc::RTCDtlsFingerprint;
+using node_webrtc::RTCIceCredentialType;
+using node_webrtc::RTCOAuthCredential;
+using node_webrtc::RTCOfferOptions;
+using node_webrtc::RTCPriorityType ;
+using node_webrtc::RTCSdpType;
+using node_webrtc::Validation;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+using webrtc::DataChannelInit;
+using webrtc::IceCandidateInterface;
+using webrtc::SessionDescriptionInterface;
+
+using BundlePolicy = webrtc::PeerConnectionInterface::BundlePolicy;
+using IceServer = webrtc::PeerConnectionInterface::IceServer;
+using IceTransportsType = webrtc::PeerConnectionInterface::IceTransportsType;
+using RTCConfiguration = webrtc::PeerConnectionInterface::RTCConfiguration;
+using RTCOfferAnswerOptions = webrtc::PeerConnectionInterface::RTCOfferAnswerOptions;
+using RtcpMuxPolicy = webrtc::PeerConnectionInterface::RtcpMuxPolicy;
+using SdpParseError = webrtc::SdpParseError;
+
+static RTCOAuthCredential CreateRTCOAuthCredential(
+    const std::string& macKey,
+    const std::string& accessToken) {
+  return RTCOAuthCredential(macKey, accessToken);
+}
+
+Validation<RTCOAuthCredential> Converter<Local<Value>, RTCOAuthCredential>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<RTCOAuthCredential>(
+      [](const Local<Object> object) {
+        return curry(CreateRTCOAuthCredential)
+            % GetRequired<std::string>(object, "macKey")
+            * GetRequired<std::string>(object, "accessToken");
+      });
+}
+
+Validation<RTCIceCredentialType> Converter<Local<Value>, RTCIceCredentialType>::Convert(const Local<Value> value) {
+    return From<std::string>(value).FlatMap<RTCIceCredentialType>(
+        [](const std::string string) {
+          if (string == "password") {
+            return Validation<RTCIceCredentialType>::Valid(kPassword);
+          } else if (string == "oauth") {
+            return Validation<RTCIceCredentialType>::Valid(kOAuth);
+          }
+          return Validation<RTCIceCredentialType>::Invalid(R"(Expected "password" or "oauth")");
+        });
+}
+
+static Validation<IceServer> CreateIceServer(
+    const Either<std::string, std::vector<std::string>>& urlOrUrls,
+    const std::string& username,
+    const Either<std::string, RTCOAuthCredential>& credential,
+    const RTCIceCredentialType credentialType) {
+  if (credential.IsRight() || credentialType != RTCIceCredentialType::kPassword) {
+    return Validation<IceServer>::Invalid("OAuth is not currently supported");
+  }
+  IceServer iceServer;
+  iceServer.uri = urlOrUrls.FromLeft("");
+  iceServer.urls = urlOrUrls.FromRight(std::vector<std::string>());
+  iceServer.username = username;
+  iceServer.password = credential.UnsafeFromLeft();
+  return Validation<IceServer>::Valid(iceServer);
+}
+
+Validation<IceServer> Converter<Local<Value>, IceServer>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<IceServer>(
+      [](const Local<Object> object) {
+        return Validation<IceServer>::Join(curry(CreateIceServer)
+            % GetRequired<Either<std::string, std::vector<std::string>>>(object, "urls")
+            * GetOptional<std::string>(object, "username", "")
+            * GetOptional<Either<std::string, RTCOAuthCredential>>(object, "credential", Either<std::string, RTCOAuthCredential>::Left(""))
+            * GetOptional<RTCIceCredentialType>(object, "credentialType", kPassword));
+      });
+}
+
+Validation<IceTransportsType> Converter<Local<Value>, IceTransportsType>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<IceTransportsType>(
+      [](const std::string string) {
+        if (string == "all") {
+          return Validation<IceTransportsType>::Valid(IceTransportsType::kAll);
+        } else if (string == "relay") {
+          return Validation<IceTransportsType>::Valid(IceTransportsType::kRelay);
+        }
+        return Validation<IceTransportsType>::Invalid(R"(Expected "all" or "relay")");
+      });
+}
+
+Validation<BundlePolicy> Converter<Local<Value>, BundlePolicy>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<BundlePolicy>(
+      [](const std::string string) {
+        if (string == "balanced") {
+          return Validation<BundlePolicy>::Valid(BundlePolicy::kBundlePolicyBalanced);
+        } else if (string == "max-compat") {
+          return Validation<BundlePolicy>::Valid(BundlePolicy::kBundlePolicyMaxCompat);
+        } else if (string == "max-bundle") {
+          return Validation<BundlePolicy>::Valid(BundlePolicy::kBundlePolicyMaxBundle);
+        }
+        return Validation<BundlePolicy>::Invalid(R"(Expected "balanced", "max-compat" or "max-bundle")");
+      });
+}
+
+Validation<RtcpMuxPolicy> Converter<Local<Value>, RtcpMuxPolicy>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<RtcpMuxPolicy>(
+      [](const std::string string) {
+        if (string == "negotiate") {
+          return Validation<RtcpMuxPolicy>::Valid(RtcpMuxPolicy::kRtcpMuxPolicyNegotiate);
+        } else if (string == "require") {
+          return Validation<RtcpMuxPolicy>::Valid(RtcpMuxPolicy::kRtcpMuxPolicyRequire);
+        }
+        return Validation<RtcpMuxPolicy>::Invalid(R"(Expected "negotiate" or "require")");
+      });
+}
+
+static RTCDtlsFingerprint CreateRTCDtlsFingerprint(
+    const Maybe<std::string>& algorithm,
+    const Maybe<std::string>& value) {
+  return RTCDtlsFingerprint(algorithm, value);
+}
+
+Validation<RTCDtlsFingerprint> Converter<Local<Value>, RTCDtlsFingerprint>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<RTCDtlsFingerprint>(
+      [](const Local<Object> object) {
+        return curry(CreateRTCDtlsFingerprint)
+            % GetOptional<std::string>(object, "algorithm")
+            * GetOptional<std::string>(object, "value");
+      });
+}
+
+static RTCConfiguration CreateRTCConfiguration(
+    const std::vector<IceServer>& iceServers,
+    const IceTransportsType iceTransportsPolicy,
+    const BundlePolicy bundlePolicy,
+    const RtcpMuxPolicy rtcpMuxPolicy,
+    const Maybe<std::string>&,
+    const Maybe<std::vector<Local<Object>>>&,
+    const uint32_t) {
+  RTCConfiguration configuration;
+  configuration.servers = iceServers;
+  configuration.type = iceTransportsPolicy;
+  configuration.bundle_policy = bundlePolicy;
+  configuration.rtcp_mux_policy = rtcpMuxPolicy;
+  return configuration;
+}
+
+Validation<RTCConfiguration> Converter<Local<Value>, RTCConfiguration>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<RTCConfiguration>(
+      [](const Local<Object> object) {
+        return curry(CreateRTCConfiguration)
+            % GetOptional<std::vector<IceServer>>(object, "iceServers", std::vector<IceServer>())
+            * GetOptional<IceTransportsType>(object, "iceTransportPolicy", IceTransportsType::kAll)
+            * GetOptional<BundlePolicy>(object, "bundlePolicy", BundlePolicy::kBundlePolicyBalanced)
+            * GetOptional<RtcpMuxPolicy>(object, "rtcpMuxPolicy", RtcpMuxPolicy::kRtcpMuxPolicyRequire)
+            * GetOptional<std::string>(object, "peerIdentity")
+            * GetOptional<std::vector<Local<Object>>>(object, "certificates")
+            // TODO(mroberts): Implement EnforceRange and change to uint8_t.
+            * GetOptional<uint32_t>(object, "iceCandidatePoolSize", 0);
+      });
+}
+
+static RTCOfferOptions CreateRTCOfferOptions(
+    const bool voiceActivityDetection,
+    const bool iceRestart,
+    const Maybe<bool> offerToReceiveAudio,
+    const Maybe<bool> offerToReceiveVideo) {
+  RTCOfferAnswerOptions options;
+  options.ice_restart = iceRestart;
+  options.voice_activity_detection = voiceActivityDetection;
+  options.offer_to_receive_audio = offerToReceiveAudio.Map(
+      [](const bool boolean) { return boolean ? RTCOfferAnswerOptions::kOfferToReceiveMediaTrue : 0; }
+  ).FromMaybe(RTCOfferAnswerOptions::kUndefined);
+  options.offer_to_receive_video = offerToReceiveVideo.Map(
+      [](const bool boolean) { return boolean ? RTCOfferAnswerOptions::kOfferToReceiveMediaTrue : 0; }
+  ).FromMaybe(RTCOfferAnswerOptions::kUndefined);
+  return RTCOfferOptions(options);
+}
+
+Validation<RTCOfferOptions> Converter<Local<Value>, RTCOfferOptions>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<RTCOfferOptions>(
+      [](const Local<Object> object) {
+        return curry(CreateRTCOfferOptions)
+            % GetOptional<bool>(object, "voiceActivityDetection", true)
+            * GetOptional<bool>(object, "iceRestart", false)
+            * GetOptional<bool>(object, "offerToReceiveAudio")
+            * GetOptional<bool>(object, "offerToReceiveVideo");
+      });
+}
+
+static RTCAnswerOptions CreateRTCAnswerOptions(const bool voiceActivityDetection) {
+  RTCOfferAnswerOptions options;
+  options.voice_activity_detection = voiceActivityDetection;
+  return RTCAnswerOptions(options);
+}
+
+Validation<RTCAnswerOptions> Converter<Local<Value>, RTCAnswerOptions>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<RTCAnswerOptions>(
+      [](const Local<Object> object) {
+        return curry(CreateRTCAnswerOptions)
+            % GetOptional<bool>(object, "voiceActivityDetection", true);
+      });
+}
+
+Validation<RTCSdpType> Converter<Local<Value>, RTCSdpType>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<RTCSdpType>(
+      [](const std::string string) {
+        if (string == "offer") {
+          return Validation<RTCSdpType>::Valid(RTCSdpType::kOffer);
+        } else if (string == "pranswer") {
+          return Validation<RTCSdpType>::Valid(RTCSdpType::kPrAnswer);
+        } else if (string == "answer") {
+          return Validation<RTCSdpType>::Valid(RTCSdpType::kAnswer);
+        } else if (string == "rollback") {
+          return Validation<RTCSdpType>::Valid(RTCSdpType::kRollback);
+        }
+        return Validation<RTCSdpType>::Invalid(R"(Expected "offer", "pranswer", "answer" or "rollback")");
+      });
+}
+
+Validation<SessionDescriptionInterface*> CreateSessionDescriptionInterface(
+    const RTCSdpType type,
+    const std::string sdp) {
+  std::string type_;
+  switch (type) {
+    case RTCSdpType::kOffer:
+      type_ = "offer";
+      break;
+    case RTCSdpType::kPrAnswer:
+      type_ = "pranswer";
+      break;
+    case RTCSdpType::kAnswer:
+      type_ = "answer";
+      break;
+    default: // kRollback
+      return Validation<SessionDescriptionInterface*>::Invalid("Rollback is not currently supported");
+  }
+  SdpParseError error;
+  auto description = webrtc::CreateSessionDescription(type_, std::string(sdp), &error);
+  if (!description) {
+    return Validation<SessionDescriptionInterface*>::Invalid(error.description);
+  }
+  return Validation<SessionDescriptionInterface*>::Valid(description);
+}
+
+Validation<SessionDescriptionInterface*> Converter<Local<Value>, SessionDescriptionInterface*>::Convert(
+    const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<SessionDescriptionInterface*>(
+      [](const Local<Object> object) {
+        return Validation<SessionDescriptionInterface*>::Join(curry(CreateSessionDescriptionInterface)
+            % GetRequired<RTCSdpType>(object, "type")
+            * GetOptional<std::string>(object, "sdp", ""));
+      });
+}
+
+static Validation<IceCandidateInterface*> CreateIceCandidateInterface(
+    const std::string& candidate,
+    const std::string& sdpMid,
+    const int sdpMLineIndex,
+    const Maybe<std::string>&) {
+  SdpParseError error;
+  auto candidate_ = webrtc::CreateIceCandidate(sdpMid, sdpMLineIndex, candidate, &error);
+  if (!candidate_) {
+    return Validation<IceCandidateInterface*>::Invalid(error.description);
+  }
+  return Validation<IceCandidateInterface*>::Valid(candidate_);
+}
+
+Validation<IceCandidateInterface*> Converter<Local<Value>, IceCandidateInterface*>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<IceCandidateInterface*>(
+      [](const Local<Object> object) {
+        return Validation<IceCandidateInterface*>::Join(curry(CreateIceCandidateInterface)
+            % GetOptional<std::string>(object, "candidate", "")
+            * GetOptional<std::string>(object, "sdpMid", "")
+            * GetOptional<int>(object, "sdpMLineIndex", 0)
+            * GetOptional<std::string>(object, "usernameFragment"));
+      });
+}
+
+Validation<RTCPriorityType> Converter<Local<Value>, RTCPriorityType>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<RTCPriorityType>(
+      [](const std::string string) {
+        if (string == "very-low") {
+          return Validation<RTCPriorityType>::Valid(RTCPriorityType::kVeryLow);
+        } else if (string == "low") {
+          return Validation<RTCPriorityType>::Valid(RTCPriorityType::kLow);
+        } else if (string == "medium") {
+          return Validation<RTCPriorityType>::Valid(RTCPriorityType::kMedium);
+        } else if (string == "high") {
+          return Validation<RTCPriorityType>::Valid(RTCPriorityType::kHigh);
+        }
+        return Validation<RTCPriorityType>::Invalid(R"(Expected "very-low", "low", "medium" or "high")");
+      });
+}
+
+static DataChannelInit CreateDataChannelInit(
+    const bool ordered,
+    const Maybe<uint32_t> maxPacketLifeTime,
+    const Maybe<uint32_t> maxRetransmits,
+    const std::string& protocol,
+    const bool negotiated,
+    const Maybe<uint32_t> id,
+    const RTCPriorityType) {
+  DataChannelInit init;
+  init.ordered = ordered;
+  init.maxRetransmitTime = maxPacketLifeTime.Map([](const uint32_t i) { return static_cast<int>(i); }).FromMaybe(-1);
+  init.maxRetransmits = maxRetransmits.Map([](const uint32_t i) { return static_cast<int>(i); }).FromMaybe(-1);
+  init.protocol = protocol;
+  init.negotiated = negotiated;
+  init.id = id.Map([](const uint32_t i) { return static_cast<int>(i); }).FromMaybe(-1);
+  return init;
+}
+
+Validation<DataChannelInit> Converter<Local<Value>, DataChannelInit>::Convert(const Local<Value> value) {
+  return From<Local<Object>>(value).FlatMap<DataChannelInit>(
+      [](const Local<Object> object) {
+        return curry(CreateDataChannelInit)
+            % GetOptional<bool>(object, "ordered", true)
+            * GetOptional<uint32_t>(object, "maxPacketLifeTime")
+            * GetOptional<uint32_t>(object, "maxRetransmits")
+            * GetOptional<std::string>(object, "protocol", "")
+            * GetOptional<bool>(object, "negotiated", false)
+            * GetOptional<uint32_t>(object, "id")
+            * GetOptional<RTCPriorityType>(object, "priority", kLow);
+      });
+}

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -1,0 +1,289 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines conversion functions between WebRTC and v8 data types. We
+ * try to match the W3C-specced Web IDL as closely as possible.
+ */
+
+#ifndef SRC_CONVERTERS_WEBRTC_H_
+#define SRC_CONVERTERS_WEBRTC_H_
+
+#include "nan.h"
+#include "webrtc/api/peerconnectioninterface.h"
+
+#include "src/converters.h"
+#include "src/converters/v8.h"
+#include "src/functional/validation.h"
+
+namespace node_webrtc {
+
+/*
+ * dictionary RTCOAuthCredential {
+ *   required DOMString macKey;
+ *   required DOMString accessToken;
+ * };
+ */
+
+// NOTE(mroberts): I've added this to match the Web IDL, but our build of
+// WebRTC doesn't currently support this.
+struct RTCOAuthCredential {
+  RTCOAuthCredential(): macKey(""), accessToken("") {}
+  RTCOAuthCredential(const std::string& macKey, const std::string& accessToken): macKey(macKey), accessToken(accessToken) {}
+  const std::string macKey;
+  const std::string accessToken;
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCOAuthCredential> {
+  static Validation<RTCOAuthCredential> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCIceCredentialType {
+ *   "password",
+ *   "oauth"
+ * };
+ */
+
+enum RTCIceCredentialType {
+  kPassword,
+  kOAuth
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCIceCredentialType> {
+  static Validation<RTCIceCredentialType> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCIceServer {
+ *   required (DOMString or sequence<DOMString>) urls;
+ *            DOMString                          username;
+ *            (DOMString or RTCOAuthCredential)  credential;
+ *            RTCIceCredentialType               credentialType = "password";
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::IceServer> {
+  static Validation<webrtc::PeerConnectionInterface::IceServer> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCIceTransportPolicy {
+ *   "relay",
+ *   "all"
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::IceTransportsType> {
+  static Validation<webrtc::PeerConnectionInterface::IceTransportsType> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCBundlePolicy {
+ *   "balanced",
+ *   "max-compat",
+ *   "max-bundle"
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::BundlePolicy> {
+  static Validation<webrtc::PeerConnectionInterface::BundlePolicy> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCRtcpMuxPolicy {
+ *   // At risk due to lack of implementers' interest.
+ *   "negotiate",
+ *   "require"
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::RtcpMuxPolicy> {
+  static Validation<webrtc::PeerConnectionInterface::RtcpMuxPolicy> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCDtlsFingerprint {
+ *   DOMString algorithm;
+ *   DOMString value;
+ * };
+ */
+
+// NOTE(mroberts): I've added this to match the Web IDL, but our build of
+// WebRTC doesn't currently support this.
+struct RTCDtlsFingerprint {
+  RTCDtlsFingerprint(): algorithm(Maybe<std::string>::Nothing()), value(Maybe<std::string>::Nothing()) {}
+  RTCDtlsFingerprint(const Maybe<std::string> algorithm, const Maybe<std::string> value): algorithm(algorithm), value(value) {}
+  const Maybe<std::string> algorithm;
+  const Maybe<std::string> value;
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCDtlsFingerprint> {
+  static Validation<RTCDtlsFingerprint> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCConfiguration {
+ *   sequence<RTCIceServer>   iceServers;
+ *   RTCIceTransportPolicy    iceTransportPolicy = "all";
+ *   RTCBundlePolicy          bundlePolicy = "balanced";
+ *   RTCRtcpMuxPolicy         rtcpMuxPolicy = "require";
+ *   DOMString                peerIdentity;
+ *   sequence<RTCCertificate> certificates;
+ *   [EnforceRange]
+ *   octet                    iceCandidatePoolSize = 0;
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::RTCConfiguration> {
+  static Validation<webrtc::PeerConnectionInterface::RTCConfiguration> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCOfferAnswerOptions {
+ *   boolean voiceActivityDetection = true;
+ * };
+ */
+
+/*
+ * dictionary RTCOfferOptions : RTCOfferAnswerOptions {
+ *   boolean iceRestart = false;
+ * };
+ *
+ * partial dictionary RTCOfferOptions {
+ *   boolean offerToReceiveAudio;
+ *   boolean offerToReceiveVideo;
+ * };
+ */
+
+// NOTE(mroberts): I'm just doing something akin to a newtype here.
+struct RTCOfferOptions {
+  RTCOfferOptions(): options(webrtc::PeerConnectionInterface::RTCOfferAnswerOptions()) {}
+  explicit RTCOfferOptions(const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options): options(options) {}
+  const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCOfferOptions> {
+  static Validation<RTCOfferOptions> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCAnswerOptions : RTCOfferAnswerOptions {
+ * };
+ */
+
+// NOTE(mroberts): I'm just doing something akin to a newtype here.
+struct RTCAnswerOptions {
+  RTCAnswerOptions(): options(webrtc::PeerConnectionInterface::RTCOfferAnswerOptions()) {}
+  explicit RTCAnswerOptions(const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options): options(options) {}
+  const webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCAnswerOptions> {
+  static Validation<RTCAnswerOptions> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCSdpType {
+ *   "offer",
+ *   "pranswer",
+ *   "answer",
+ *   "rollback"
+ * };
+ */
+
+enum RTCSdpType {
+  kOffer,
+  kPrAnswer,
+  kAnswer,
+  kRollback
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCSdpType> {
+  static Validation<RTCSdpType> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCSessionDescriptionInit {
+ *   required RTCSdpType type;
+ *            DOMString  sdp = "";
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::SessionDescriptionInterface*> {
+  static Validation<webrtc::SessionDescriptionInterface*> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCIceCandidateInit {
+ *     DOMString       candidate = "";
+ *     DOMString?      sdpMid = null;
+ *     unsigned short? sdpMLineIndex = null;
+ *     DOMString       usernameFragment;
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::IceCandidateInterface*> {
+  static Validation<webrtc::IceCandidateInterface*> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * enum RTCPriorityType {
+ *   "very-low",
+ *   "low",
+ *   "medium",
+ *   "high"
+ * };
+ */
+
+enum RTCPriorityType {
+  kVeryLow,
+  kLow,
+  kMedium,
+  kHigh
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, RTCPriorityType> {
+  static Validation<RTCPriorityType> Convert(v8::Local<v8::Value> value);
+};
+
+/*
+ * dictionary RTCDataChannelInit {
+ *   boolean         ordered = true;
+ *   unsigned short  maxPacketLifeTime;
+ *   unsigned short  maxRetransmits;
+ *   USVString       protocol = "";
+ *   boolean         negotiated = false;
+ *   [EnforceRange]
+ *   unsigned short  id;
+ *   RTCPriorityType priority = "low";
+ * };
+ */
+
+template <>
+struct Converter<v8::Local<v8::Value>, webrtc::DataChannelInit> {
+  static Validation<webrtc::DataChannelInit> Convert(v8::Local<v8::Value> value);
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_CONVERTERS_WEBRTC_H_

--- a/src/functional/curry.h
+++ b/src/functional/curry.h
@@ -1,0 +1,66 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines a function for currying functions. It is borrowed from
+ * https://stackoverflow.com/a/26768388
+ */
+
+#ifndef SRC_FUNCTIONAL_CURRY_H_
+#define SRC_FUNCTIONAL_CURRY_H_
+
+#include <functional>
+
+namespace _dtl {
+
+template <typename FUNCTION>
+struct _curry;
+
+// specialization for functions with a single argument
+template <typename R, typename T>
+struct _curry<std::function<R(T)>> {
+  using type = std::function<R(T)>;
+
+  const type result;
+
+  _curry(type fun): result(fun) {}
+};
+
+// recursive specialization for functions with more arguments
+template <typename R, typename T, typename...Ts> struct
+_curry<std::function<R(T, Ts...)>> {
+  using remaining_type = typename _curry<std::function<R(Ts...)> >::type;
+
+  using type = std::function<remaining_type(T)>;
+
+  const type result;
+
+  _curry(std::function<R(T, Ts...)> fun): result (
+    [=](const T& t) {
+      return _curry<std::function<R(Ts...)>>(
+        [=](const Ts&...ts) {
+          return fun(t, ts...);
+        }
+      ).result;
+    }
+  ) {}
+};
+
+}
+
+template <typename R, typename...Ts>
+auto curry(const std::function<R(Ts...)> fun) -> typename _dtl::_curry<std::function<R(Ts...)>>::type {
+  return _dtl::_curry<std::function<R(Ts...)>>(fun).result;
+}
+
+template <typename R, typename...Ts>
+auto curry(R(* const fun)(Ts...)) -> typename _dtl::_curry<std::function<R(Ts...)>>::type {
+  return _dtl::_curry<std::function<R(Ts...)>>(fun).result;
+}
+
+#endif  // SRC_FUNCTIONAL_CURRY_H_

--- a/src/functional/either.h
+++ b/src/functional/either.h
@@ -1,0 +1,165 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines Either, a sum type, modeled after the Haskell's:
+ * https://hackage.haskell.org/package/base/docs/Data-Either.html
+ */
+
+#ifndef SRC_FUNCTIONAL_EITHER_H_
+#define SRC_FUNCTIONAL_EITHER_H_
+
+#include <cassert>
+#include <functional>
+
+namespace node_webrtc {
+
+/**
+ * Either is a sum type. It either contains a value of type L ("left") or a
+ * value of type R ("right").
+ * @tparam L the left type
+ * @tparam R the right type
+ */
+template <typename L, typename R>
+class Either {
+ public:
+  // TODO(mroberts): This is no good.
+  Either(): _is_right(false), _left(L()), _right(R()) {}
+
+  /**
+   * Either forms an applicative. Apply an Either.
+   * @tparam F the type of a function from R to S
+   * @param f an Either of a function from R to S
+   * @return the result of applying the Either
+   */
+  template <typename F>
+  Either<L, typename std::result_of<F(R)>::type> Apply(const Either<L, F> f) const {
+    if (f.IsLeft()) {
+      return Either::Left(f.UnsafeFromLeft());
+    } else if (IsLeft()) {
+      return Either::Left(_left);
+    }
+    return Either::Right(f.UnsafeFromRight()(_right));
+  }
+
+  /**
+   * Check whether or not the Either is "left".
+   * @return true if the Either is left; otherwise, false
+   */
+  bool IsLeft() const {
+    return !_is_right;
+  }
+
+  /**
+   * Check whether or not the Either is "right".
+   * @return true if the Either is right; otherwise, false
+   */
+  bool IsRight() const {
+    return _is_right;
+  }
+
+  /**
+   * Eliminate an Either. You must provide two functions for both the left and
+   * right cases that convert each value to some common type T.
+   * @tparam T the common type to convert to
+   * @param fromLeft a function that converts values of type L to T
+   * @param fromRight a function that converts values of type R to T
+   * @return a value of type T
+   */
+  template <typename T>
+  T FromEither(std::function<T(const L)> fromLeft, std::function<T(const R)> fromRight) const {
+    return _is_right ? fromRight(_right) : fromLeft(_left);
+  }
+
+  /**
+   * Eliminate an Either. You must provide a default value to handle the "right"
+   * case.
+   * @param default_value the default value to use in the right case
+   * @return the value in the Either, if "left"; otherwise, the default value
+   */
+  L FromLeft(const L default_value) const {
+    return _is_right ? default_value : _left;
+  }
+
+  /**
+   * Eliminate an Either. You must provide a default value to handle the "left"
+   * case.
+   * @param default_value the default value to use in the left case
+   * @return the value in the Either, if "right"; otherwise, the default value
+   */
+  R FromRight(const R default_value) const {
+    return _is_right ? _right : default_value;
+  }
+
+  /**
+   * Either forms a functor. Map a function over Either.
+   * @tparam F the type of a function from R to S
+   * @param f a function from R to S
+   * @return the mapped Either
+   */
+  template <typename F>
+  Either<L, typename std::result_of<F(R)>::type> Map(F f) const {
+    return _is_right ? Either(f(_right)) : this;
+  }
+
+  /**
+   * Either forms an alternative. If "this" is "right", return this; otherwise, that
+   * @param that another Either
+   * @return this or that
+   */
+  Either<L, R> Or(const Either<L, R> that) const {
+    return _is_right ? this : that;
+  }
+
+  /**
+   * Unsafely eliminate an Either. This only works if the Either is "left".
+   * @return the left value in the Either, if left; otherwise, undefined
+   */
+  L UnsafeFromLeft() const {
+    assert(!_is_right);
+    return _left;
+  }
+
+  /**
+   * Unsafely eliminate an Either. This only works if the Either is "right".
+   * @return the right value in the Either, if right; otherwise, undefined
+   */
+  R UnsafeFromRight() const {
+    assert(_is_right);
+    return _right;
+  }
+
+  /**
+   * Construct a "left" Either.
+   * @param left the value to inject into the Either
+   * @return a left Either
+   */
+  static Either<L, R> Left(const L left) {
+    return Either(false, left, R());
+  }
+
+  /**
+   * Construct a "right" Either.
+   * @param right the value to inject into the Either
+   * @return a right Either
+   */
+  static Either<L, R> Right(const R right) {
+    return Either(true, L(), right);
+  }
+
+ private:
+  Either(bool is_right, const L left, const R right): _is_right(is_right), _left(left), _right(right) {}
+
+  const bool _is_right;
+  const L _left;
+  const R _right;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_FUNCTIONAL_EITHER_H_

--- a/src/functional/maybe.h
+++ b/src/functional/maybe.h
@@ -1,0 +1,132 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines Maybe, modeled after the Haskell's:
+ * https://hackage.haskell.org/package/base/docs/Data-Maybe.html
+ */
+
+#ifndef SRC_FUNCTIONAL_MAYBE_H_
+#define SRC_FUNCTIONAL_MAYBE_H_
+
+#include <cassert>
+#include <type_traits>
+
+namespace node_webrtc {
+
+/**
+ * Maybe represents an optional value.
+ * @tparam T the value type
+ */
+template <typename T>
+class Maybe {
+ public:
+  /**
+   * Construct an empty Maybe.
+   */
+  Maybe(): _is_just(false), _value(T()) {}
+
+  /**
+   * Construct a non-empty Maybe.
+   * @param value the value to inject into the Maybe
+   */
+  explicit Maybe(const T value): _is_just(true), _value(value) {}
+
+  /**
+   * Maybe forms an applicative. Apply a Maybe.
+   * @tparam F the type of a function from T to S
+   * @param f a Maybe of a function from T to S
+   * @return the result of applying the Maybe
+   */
+  template <typename F>
+  Maybe<typename std::result_of<F(T)>::type> Apply(const Maybe<F> f) const {
+    return f.IsJust() && _is_just ? Maybe(f.UnsafeFromJust()(_value)) : Nothing();
+  }
+
+  /**
+   * Eliminate a Maybe. You must provide a default value to handle the empty
+   * case.
+   * @param default_value the default value to use in the empty case
+   * @return the value in the Maybe, if non-empty; otherwise, the default value
+   */
+  T FromMaybe(T default_value) const {
+    return _is_just ? _value : default_value;
+  }
+
+  /**
+   * Check whether or not the Maybe is non-empty.
+   * @return true if the Maybe is non-empty; otherwise, false
+   */
+  bool IsJust() const {
+    return _is_just;
+  }
+
+  /**
+   * Check whether or not the Maybe is empty.
+   * @return true if the Maybe is empty; otherwise, false
+   */
+  bool IsNothing() const {
+    return !_is_just;
+  }
+
+  /**
+   * Maybe forms a functor. Map a function over Maybe.
+   * @tparam F the type of a function from T to S
+   * @param f a function from T to S
+   * @return the mapped Maybe
+   */
+  template <typename F>
+  Maybe<typename std::result_of<F(T)>::type> Map(F f) const {
+    return _is_just
+           ? Maybe<typename std::result_of<F(T)>::type>::Just(f(_value))
+           : Maybe<typename std::result_of<F(T)>::type>::Nothing();
+  }
+
+  /**
+   * Maybe forms an alternative. If "this" is non-empty, return this; otherwise, that
+   * @param that another Maybe
+   * @return this or that
+   */
+  Maybe<T> Or(const Maybe<T> that) const {
+    return _is_just ? this : that;
+  }
+
+  /**
+   * Unsafely eliminate a Maybe. This only works if the Maybe is non-empty.
+   * @return the value in the Maybe, if non-empty; otherwise, undefined
+   */
+  T UnsafeFromJust() const {
+    assert(_is_just);
+    return _value;
+  }
+
+  /**
+   * Construct an empty Maybe.
+   * @return an empty Maybe
+   */
+  static Maybe<T> Nothing() {
+    return Maybe();
+  }
+
+  /**
+   * Construct a non-empty Maybe.
+   * @param value the value present in the Maybe
+   * @return a non-empty Maybe
+   */
+  static Maybe<T> Just(const T value) {
+    return Maybe(value);
+  }
+
+ private:
+  const bool _is_just;
+  const T _value;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_FUNCTIONAL_MAYBE_H_

--- a/src/functional/operators.h
+++ b/src/functional/operators.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines operators that make it nicer to work with alternatives,
+ * applicatives, and functors. They are modeled after FTL:
+ * https://github.com/beark/ftl
+ */
+
+#ifndef SRC_FUNCTIONAL_OPERATORS_H_
+#define SRC_FUNCTIONAL_OPERATORS_H_
+
+namespace node_webrtc {
+
+/**
+ * Syntactic sugar for Or
+ * @tparam T the type of some alternative
+ * @tparam A some type A
+ * @param left an alternative of a value of type A
+ * @param right an alternative of a value of type A
+ * @return an alternative of a value of type A
+ */
+template <template <typename> class T, typename A>
+static T<A> operator|(const T<A> left, const T<A> right) {
+  return left.Or(right);
+}
+
+/**
+ * Syntactic sugar for Apply
+ * @tparam T the type of some functor
+ * @tparam F the type of a function from A to B
+ * @tparam A some type A
+ * @param f an applicative of a function from A to B
+ * @param a a value of type A
+ * @return an applicative of a value of type B
+ */
+template <template <typename> class T, typename F, typename A>
+static T<typename std::result_of<F(A)>::type> operator*(const T<F> f, const T<A> a) {
+  return a.Apply(f);
+}
+
+/**
+ * Syntactic sugar for Map
+ * @tparam T the type of some functor
+ * @tparam F the type of a function from A to B
+ * @tparam A some type A
+ * @param f a function from A to B
+ * @param a a value of type A
+ * @return a functor of a value of type B
+ */
+template <template <typename> class T, typename F, typename A>
+static T<typename std::result_of<F(A)>::type> operator%(const F f, const T<A> a) {
+  return a.Map(f);
+}
+
+}  // namespace node_webrtc
+
+#endif  // SRC_FUNCTIONAL_OPERATORS_H_

--- a/src/functional/validation.h
+++ b/src/functional/validation.h
@@ -1,0 +1,211 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+
+/*
+ * This file defines Validation, modeled after
+ * https://hackage.haskell.org/package/Validation
+ */
+
+#ifndef SRC_FUNCTIONAL_VALIDATION_H_
+#define SRC_FUNCTIONAL_VALIDATION_H_
+
+#include <cassert>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace node_webrtc {
+
+typedef std::string Error;
+
+typedef std::vector<Error> Errors;
+
+/**
+ * A Validation is similar to Either, in that it is a sum type whose "left"
+ * values are a collection of errors and whose "right" values are some type T;
+ * however, Validation can be used to represent values that need to be
+ * validated. They can accrue multiple errors during the validation process.
+ * @tparam T the type of value to validate
+ */
+template <typename T>
+class Validation {
+ public:
+  // TODO(mroberts): This is no good.
+  Validation(): _is_valid(false), _value(T()) {}
+
+  /**
+   * Construct a valid Validation. The value passed is assumed to be valid.
+   * @param value the value to inject into the Validation
+   */
+  explicit Validation(const T value): _is_valid(true), _value(value) {}
+
+  /**
+   * Validation forms an applicative. Apply a validation.
+   * @tparam F the type of a function from T to S
+   * @param f a Validation of a function from T to S
+   * @return the result of applying the Validation
+   */
+  template <typename F>
+  Validation<typename std::result_of<F(T)>::type> Apply(const Validation<F> f) const {
+    if (f.IsInvalid()) {
+      auto errors = f.ToErrors();
+      errors.insert(errors.end(), _errors.begin(), _errors.end());
+      return Validation<typename std::result_of<F(T)>::type>::Invalid(errors);
+    } else if (IsInvalid()) {
+      return Validation<typename std::result_of<F(T)>::type>::Invalid(_errors);
+    }
+    return Validation<typename std::result_of<F(T)>::type>::Valid(f.UnsafeFromValid()(_value));
+  }
+
+  /**
+   * Validation does not form a lawful Monad. Nevertheless, this is a useful
+   * function to have.
+   * @tparam S some type S
+   * @param f a function from T to a Validation of S
+   * @return a Validation of S
+   */
+  template <typename S>
+  Validation<S> FlatMap(std::function<Validation<S>(T)> f) const {
+    if (!_is_valid) {
+      return Validation<S>::Invalid(_errors);
+    }
+    return f(_value);
+  }
+
+  /**
+   * Eliminate a Validation. You must provide a default value to handle the
+   * invalid case.
+   * @param default_value the default value to use in the invalid case
+   * @return the value in the Validation, if valid; otherwise, the default value
+   */
+  T FromValidation(const T default_value) const {
+    return _is_valid ? _value : default_value;
+  }
+
+  /**
+   * Check whether or not the Validation is invalid.
+   * @return true if the Validation is invalid; otherwise, false
+   */
+  bool IsInvalid() const {
+    return !_is_valid;
+  }
+
+  /**
+   * Check whether or not the Validation is valid.
+   * @return true if the Validation is valid; otherwise, false
+   */
+  bool IsValid() const {
+    return _is_valid;
+  }
+
+  /**
+   * Validation forms a functor. Map a function over Validation.
+   * @tparam F the type of a function from type T to S
+   * @param f a function from type T to S
+   * @return the mapped Validation
+   */
+  template <typename F>
+  Validation<typename std::result_of<F(T)>::type> Map(F f) const {
+    return _is_valid
+           ? Validation<typename std::result_of<F(T)>::type>::Valid(f(_value))
+           : Validation<typename std::result_of<F(T)>::type>::Invalid(_errors);
+  }
+
+  /**
+   * Validation forms an alternative. If "this" is valid, return this; otherwise, that
+   * @param that another Validation
+   * @return this or that
+   */
+  Validation<T> Or(const Validation<T> that) const {
+    return _is_valid ? Validation<T>::Valid(_value) : that;
+  }
+
+  /**
+   * Get the errors in a Validation.
+   * @return errors
+   */
+  Errors ToErrors() const {
+    return std::vector<Error>(_errors);
+  }
+
+  /**
+   * Unsafely eliminate a Validation. This only works if the Validation is
+   * valid.
+   * @return the value in the Validation, if valid; otherwise, undefined
+   */
+  T UnsafeFromValid() const {
+    assert(_is_valid);
+    return _value;
+  }
+
+  /**
+   * Construct an invalid Validation.
+   * @param error error specifying why the Validation is invalid
+   * @return an invalid Validation
+   */
+  static Validation<T> Invalid(Error error) {
+    return Validation(false, std::vector<Error>({ error }));
+  }
+
+  /**
+   * Construct an invalid Validation.
+   * @param errors errors specifying why the Validation is invalid
+   * @return an invalid Validation
+   */
+  static Validation<T> Invalid(Errors errors) {
+    return Validation(false, errors);
+  }
+
+  /**
+   * Validation does not form a lawful Monad. Nevertheless, this is a useful
+   * function to have.
+   * @param tt a Validation for a Validation of T
+   */
+  static Validation<T> Join(const Validation<Validation<T>> tt) {
+    return tt.template FlatMap<T>([](const Validation<T> t) { return t; });
+  }
+
+  /**
+   * Sequence a vector of Validations into a Validation of a vector.
+   * @param values a vector of Validations
+   * @return a Validation of a vector
+   */
+  static Validation<std::vector<T>> Sequence(const std::vector<Validation<T>> values) {
+    auto errors = std::vector<Error>();
+    auto valids = std::vector<T>();
+    for (auto value : values) {
+      if (value.IsValid()) {
+        valids.push_back(value.UnsafeFromValid());
+      } else {
+        auto thoseErrors = value.ToErrors();
+        errors.insert(errors.end(), thoseErrors.begin(), thoseErrors.end());
+      }
+    }
+    return errors.empty() ? Validation<std::vector<T>>::Valid(valids) : Validation<std::vector<T>>::Invalid(errors);
+  }
+
+  /**
+   * Construct a valid Validation.
+   * @param value the value to inject into the Validation
+   * @return a valid Validation
+   */
+  static Validation<T> Valid(const T value) {
+    return Validation(value);
+  }
+
+ private:
+  Validation(const bool is_valid, const Errors errors): _errors(errors), _is_valid(is_valid), _value(T()) {}
+
+  const Errors _errors;
+  const bool _is_valid;
+  const T _value;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_FUNCTIONAL_VALIDATION_H_

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -10,15 +10,20 @@
 #include "webrtc/base/refcountedobject.h"
 
 #include "common.h"
+#include "converters/arguments.h"
+#include "converters/webrtc.h"
 #include "create-answer-observer.h"
 #include "create-offer-observer.h"
 #include "datachannel.h"
+#include "functional/maybe.h"
 #include "peerconnectionfactory.h"
 #include "rtcstatsresponse.h"
 #include "set-local-description-observer.h"
 #include "set-remote-description-observer.h"
 #include "stats-observer.h"
 
+using node_webrtc::From;
+using node_webrtc::Maybe;
 using node_webrtc::PeerConnection;
 using node_webrtc::PeerConnectionFactory;
 using v8::External;
@@ -33,6 +38,14 @@ using v8::String;
 using v8::Uint32;
 using v8::Value;
 using v8::Array;
+using webrtc::DataChannelInit;
+using webrtc::IceCandidateInterface;
+using webrtc::SessionDescriptionInterface;
+
+using IceConnectionState = webrtc::PeerConnectionInterface::IceConnectionState;
+using IceGatheringState = webrtc::PeerConnectionInterface::IceGatheringState;
+using RTCConfiguration = webrtc::PeerConnectionInterface::RTCConfiguration;
+using SignalingState = webrtc::PeerConnectionInterface::SignalingState;
 
 Nan::Persistent<Function> PeerConnection::constructor;
 
@@ -40,15 +53,12 @@ Nan::Persistent<Function> PeerConnection::constructor;
 // PeerConnection
 //
 
-PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList)
+PeerConnection::PeerConnection(RTCConfiguration configuration)
   : loop(uv_default_loop()) {
   _createOfferObserver = new rtc::RefCountedObject<CreateOfferObserver>(this);
   _createAnswerObserver = new rtc::RefCountedObject<CreateAnswerObserver>(this);
   _setLocalDescriptionObserver = new rtc::RefCountedObject<SetLocalDescriptionObserver>(this);
   _setRemoteDescriptionObserver = new rtc::RefCountedObject<SetRemoteDescriptionObserver>(this);
-
-  webrtc::PeerConnectionInterface::RTCConfiguration configuration;
-  configuration.servers = iceServerList;
 
   // TODO(mroberts): Read `factory` (non-standard) from RTCConfiguration?
   _factory = PeerConnectionFactory::GetOrCreateDefault();
@@ -256,84 +266,14 @@ NAN_METHOD(PeerConnection::New) {
     return Nan::ThrowTypeError("Use the new operator to construct the PeerConnection.");
   }
 
-  webrtc::PeerConnectionInterface::IceServers iceServerList;
-
-  // Check if we have a configuration object
-  if (info[0]->IsObject()) {
-    const Local<Object> obj = info[0]->ToObject();
-
-    // Extract keys into array for iteration
-    const Local<Array> props = obj->GetPropertyNames();
-
-    // Iterate all of the top-level config keys
-    for (uint32_t i = 0; i < props->Length(); i++) {
-      // Get the key and value for this particular config field
-      const Local<String> key = props->Get(i)->ToString();
-      const Local<Value> value = obj->Get(key);
-
-      // Annoyingly convert to std::string
-      String::Utf8Value _key(key);
-      std::string strKey = std::string(*_key);
-
-      // Handle iceServers configuration
-      if (strKey == "iceServers" && value->IsArray()) {
-        const Handle<Array> iceServers = Handle<Array>::Cast(value);
-
-        // Iterate over all of the ice servers configured
-        for (uint32_t j = 0; j < iceServers->Length(); j++) {
-          if (iceServers->Get(j)->IsObject()) {
-
-            const Local<Object> iceServerObj = iceServers->Get(j)->ToObject();
-            webrtc::PeerConnectionInterface::IceServer iceServer;
-
-            const Local<Array> iceProps = iceServerObj->GetPropertyNames();
-
-            // Now we have an iceserver object in iceServerObj - Lets iterate all of its fields
-            for (uint32_t y = 0; y < iceProps->Length(); y++) {
-              String::Utf8Value _iceServerKey(iceProps->Get(y)->ToString());
-              std::string iceServerKey = std::string(*_iceServerKey);
-
-              Local<Value> iceValue = iceServerObj->Get(iceProps->Get(y)->ToString());
-
-              // Handle each field by casting the data and assigning to our iceServer intsance
-              if ((iceServerKey == "url" || iceServerKey == "urls") && iceValue->IsString()) {
-                String::Utf8Value _iceUrl(iceValue->ToString());
-                std::string iceUrl = std::string(*_iceUrl);
-
-                iceServer.uri = iceUrl;
-              } else if ((iceServerKey == "url" || iceServerKey == "urls") && iceValue->IsArray()) {
-                Handle<Array> iceUrls = Handle<Array>::Cast(iceValue);
-
-                for (uint32_t x = 0; x < iceUrls->Length(); x++) {
-                  String::Utf8Value _iceUrlsEntry(iceUrls->Get(x)->ToString());
-                  std::string iceUrlsEntry = std::string(*_iceUrlsEntry);
-
-                  iceServer.urls.push_back(iceUrlsEntry);
-                }
-              } else if (iceServerKey == "credential" && iceValue->IsString()) {
-                String::Utf8Value _icePassword(iceValue->ToString());
-                std::string icePassword = std::string(*_icePassword);
-
-                iceServer.password = icePassword;
-              } else if (iceServerKey == "username" && iceValue->IsString()) {
-                String::Utf8Value _iceUsername(iceValue->ToString());
-                std::string iceUsername = std::string(*_iceUsername);
-
-                iceServer.username = iceUsername;
-              }
-            }
-
-            // Lastly we push the created ICE server to our iceServerList, to be passed to the 'real' PeerConnection constructor
-            iceServerList.push_back(iceServer);
-          }
-        }
-      }
-      // else if (strKey == "offerToReceiveAudio") ... Handle more config here. For now i just need ICE
-    }
+  auto maybeConfiguration = From<Maybe<RTCConfiguration>, Nan::NAN_METHOD_ARGS_TYPE>(info);
+  if (maybeConfiguration.IsInvalid()) {
+    auto error = maybeConfiguration.ToErrors()[0];
+    return Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
   }
 
   // Tell em whats up
-  PeerConnection* obj = new PeerConnection(iceServerList);
+  auto obj = new PeerConnection(maybeConfiguration.UnsafeFromValid().FromMaybe(RTCConfiguration()));
   obj->Wrap(info.This());
   obj->Ref();
 
@@ -343,6 +283,15 @@ NAN_METHOD(PeerConnection::New) {
 
 NAN_METHOD(PeerConnection::CreateOffer) {
   TRACE_CALL;
+
+  // TODO: Actually use the options.
+  auto validationOptions = From<Maybe<RTCOfferOptions>, Nan::NAN_METHOD_ARGS_TYPE>(info).Map(
+  [](const Maybe<RTCOfferOptions> maybeOptions) { return maybeOptions.FromMaybe(RTCOfferOptions()); });
+  if (validationOptions.IsInvalid()) {
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(validationOptions.ToErrors()[0]).ToLocalChecked());
+    return;
+  }
 
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
@@ -357,6 +306,15 @@ NAN_METHOD(PeerConnection::CreateOffer) {
 NAN_METHOD(PeerConnection::CreateAnswer) {
   TRACE_CALL;
 
+  // TODO: Actually use the options.
+  auto validationOptions = From<Maybe<RTCAnswerOptions>, Nan::NAN_METHOD_ARGS_TYPE>(info).Map(
+  [](const Maybe<RTCAnswerOptions> maybeOptions) { return maybeOptions.FromMaybe(RTCAnswerOptions()); });
+  if (validationOptions.IsInvalid()) {
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(validationOptions.ToErrors()[0]).ToLocalChecked());
+    return;
+  }
+
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
   if (self->_jinglePeerConnection != nullptr) {
@@ -370,19 +328,20 @@ NAN_METHOD(PeerConnection::CreateAnswer) {
 NAN_METHOD(PeerConnection::SetLocalDescription) {
   TRACE_CALL;
 
+  auto maybeDescription = From<SessionDescriptionInterface*, Nan::NAN_METHOD_ARGS_TYPE>(info);
+  if (maybeDescription.IsInvalid()) {
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(maybeDescription.ToErrors()[0]).ToLocalChecked());
+    return;
+  }
+  auto description = maybeDescription.UnsafeFromValid();
+
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
   if (self->_jinglePeerConnection != nullptr) {
-    Local<Object> desc = Local<Object>::Cast(info[0]);
-    String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
-    String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
-
-    std::string type = *_type;
-    std::string sdp = *_sdp;
-    webrtc::SdpParseError error;
-    webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
-
-    self->_jinglePeerConnection->SetLocalDescription(self->_setLocalDescriptionObserver, sdi);
+    self->_jinglePeerConnection->SetLocalDescription(self->_setLocalDescriptionObserver, description);
+  } else {
+    delete description;
   }
 
   TRACE_END;
@@ -392,19 +351,20 @@ NAN_METHOD(PeerConnection::SetLocalDescription) {
 NAN_METHOD(PeerConnection::SetRemoteDescription) {
   TRACE_CALL;
 
+  auto maybeDescription = From<SessionDescriptionInterface*, Nan::NAN_METHOD_ARGS_TYPE>(info);
+  if (maybeDescription.IsInvalid()) {
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(maybeDescription.ToErrors()[0]).ToLocalChecked());
+    return;
+  }
+  auto description = maybeDescription.UnsafeFromValid();
+
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
 
   if (self->_jinglePeerConnection != nullptr) {
-    Local<Object> desc = Local<Object>::Cast(info[0]);
-    String::Utf8Value _type(desc->Get(Nan::New("type").ToLocalChecked())->ToString());
-    String::Utf8Value _sdp(desc->Get(Nan::New("sdp").ToLocalChecked())->ToString());
-
-    std::string type = *_type;
-    std::string sdp = *_sdp;
-    webrtc::SdpParseError error;
-    webrtc::SessionDescriptionInterface* sdi = webrtc::CreateSessionDescription(type, sdp, &error);
-
-    self->_jinglePeerConnection->SetRemoteDescription(self->_setRemoteDescriptionObserver, sdi);
+    self->_jinglePeerConnection->SetRemoteDescription(self->_setRemoteDescriptionObserver, description);
+  } else {
+    delete description;
   }
 
   TRACE_END;
@@ -414,26 +374,23 @@ NAN_METHOD(PeerConnection::SetRemoteDescription) {
 NAN_METHOD(PeerConnection::AddIceCandidate) {
   TRACE_CALL;
 
+  auto maybeCandidate = From<IceCandidateInterface*, Nan::NAN_METHOD_ARGS_TYPE>(info);
+  if (maybeCandidate.IsInvalid()) {
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(maybeCandidate.ToErrors()[0]).ToLocalChecked());
+    return;
+  }
+  auto candidate = maybeCandidate.UnsafeFromValid();
+
   PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.This());
-  Handle<Object> sdp = Handle<Object>::Cast(info[0]);
 
-  String::Utf8Value _candidate(sdp->Get(Nan::New("candidate").ToLocalChecked())->ToString());
-  std::string candidate = *_candidate;
-  String::Utf8Value _sipMid(sdp->Get(Nan::New("sdpMid").ToLocalChecked())->ToString());
-  std::string sdp_mid = *_sipMid;
-  uint32_t sdp_mline_index = sdp->Get(Nan::New("sdpMLineIndex").ToLocalChecked())->Uint32Value();
-
-  webrtc::SdpParseError sdpParseError;
-  webrtc::IceCandidateInterface* ci = webrtc::CreateIceCandidate(sdp_mid, sdp_mline_index, candidate, &sdpParseError);
-
-  if (self->_jinglePeerConnection != nullptr && self->_jinglePeerConnection->AddIceCandidate(ci)) {
+  if (self->_jinglePeerConnection != nullptr && self->_jinglePeerConnection->AddIceCandidate(candidate)) {
     self->QueueEvent(PeerConnection::ADD_ICE_CANDIDATE_SUCCESS, static_cast<void*>(nullptr));
   } else {
+    delete candidate;
     std::string error = std::string("Failed to set ICE candidate");
     if (self->_jinglePeerConnection == nullptr) {
       error += ", no jingle peer connection";
-    } else if (sdpParseError.description.length()) {
-      error += std::string(", parse error: ") + sdpParseError.description;
     }
     error += ".";
     PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(error);
@@ -454,48 +411,20 @@ NAN_METHOD(PeerConnection::CreateDataChannel) {
     return;
   }
 
-  String::Utf8Value label(info[0]->ToString());
-  Handle<Object> dataChannelDict = Handle<Object>::Cast(info[1]);
+  auto maybeArgs = From<std::tuple<std::string, DataChannelInit>, Nan::NAN_METHOD_ARGS_TYPE>(info);
+  if (maybeArgs.IsInvalid()) {
+    TRACE_END;
+    auto error = maybeArgs.ToErrors()[0];
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
+  }
+  auto args = maybeArgs.UnsafeFromValid();
+  auto label = std::get<0>(args);
+  auto dataChannelInit = std::get<1>(args);
 
-  webrtc::DataChannelInit dataChannelInit;
-  if (dataChannelDict->Has(Nan::New("id").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("id").ToLocalChecked());
-    if (value->IsInt32()) {
-      dataChannelInit.id = value->Int32Value();
-    }
-  }
-  if (dataChannelDict->Has(Nan::New("maxRetransmitTime").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("maxRetransmitTime").ToLocalChecked());
-    if (value->IsInt32()) {
-      dataChannelInit.maxRetransmitTime = value->Int32Value();
-    }
-  }
-  if (dataChannelDict->Has(Nan::New("maxRetransmits").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("maxRetransmits").ToLocalChecked());
-    if (value->IsInt32()) {
-      dataChannelInit.maxRetransmits = value->Int32Value();
-    }
-  }
-  if (dataChannelDict->Has(Nan::New("negotiated").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("negotiated").ToLocalChecked());
-    if (value->IsBoolean()) {
-      dataChannelInit.negotiated = value->BooleanValue();
-    }
-  }
-  if (dataChannelDict->Has(Nan::New("ordered").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("ordered").ToLocalChecked());
-    if (value->IsBoolean()) {
-      dataChannelInit.ordered = value->BooleanValue();
-    }
-  }
-  if (dataChannelDict->Has(Nan::New("protocol").ToLocalChecked())) {
-    Local<Value> value = dataChannelDict->Get(Nan::New("protocol").ToLocalChecked());
-    if (value->IsString()) {
-      dataChannelInit.protocol = *String::Utf8Value(value->ToString());
-    }
-  }
+  rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_interface =
+      self->_jinglePeerConnection->CreateDataChannel(label, &dataChannelInit);
 
-  rtc::scoped_refptr<webrtc::DataChannelInterface> data_channel_interface = self->_jinglePeerConnection->CreateDataChannel(*label, &dataChannelInit);
   DataChannelObserver* observer = new DataChannelObserver(self->_factory, data_channel_interface);
 
   Local<Value> cargv[1];
@@ -564,107 +493,154 @@ NAN_METHOD(PeerConnection::Close) {
 
 NAN_GETTER(PeerConnection::GetLocalDescription) {
   TRACE_CALL;
+  (void) property;
 
-  PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
-  const webrtc::SessionDescriptionInterface* sdi = nullptr;
+  auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
-  if (self->_jinglePeerConnection != nullptr) {
-    sdi = self->_jinglePeerConnection->local_description();
-  }
-
-  Handle<Value> value;
-  if (nullptr == sdi) {
-    value = Nan::Null();
-  } else {
-    std::string sdp;
-    sdi->ToString(&sdp);
-    value = Nan::New(sdp.c_str()).ToLocalChecked();
+  Local<Value> result = Nan::Null();
+  if (self->_jinglePeerConnection) {
+    if (auto _description = self->_jinglePeerConnection->local_description()) {
+      std::string sdp;
+      if (_description->ToString(&sdp)) {
+        auto type = _description->type();
+        Local<Object> description = Nan::New<Object>();
+        Nan::Set(description, Nan::New("type").ToLocalChecked(), Nan::New(type).ToLocalChecked());
+        Nan::Set(description, Nan::New("sdp").ToLocalChecked(), Nan::New(sdp).ToLocalChecked());
+        result = description;
+      }
+    }
   }
 
   TRACE_END;
-#if NODE_MAJOR_VERSION == 0
-  info.GetReturnValue().Set(Nan::New(value));
-#else
-  info.GetReturnValue().Set(value);
-#endif
+  info.GetReturnValue().Set(result);
 }
 
 NAN_GETTER(PeerConnection::GetRemoteDescription) {
   TRACE_CALL;
 
-  PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
-  const webrtc::SessionDescriptionInterface* sdi = nullptr;
+  (void) property;
 
-  if (self->_jinglePeerConnection != nullptr) {
-    sdi = self->_jinglePeerConnection->remote_description();
-  }
+  auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
-  Handle<Value> value;
-  if (nullptr == sdi) {
-    value = Nan::Null();
-  } else {
-    std::string sdp;
-    sdi->ToString(&sdp);
-    value = Nan::New(sdp.c_str()).ToLocalChecked();
+  Local<Value> result = Nan::Null();
+  if (self->_jinglePeerConnection) {
+    if (auto _description = self->_jinglePeerConnection->remote_description()) {
+      std::string sdp;
+      if (_description->ToString(&sdp)) {
+        auto type = _description->type();
+        Local<Object> description = Nan::New<Object>();
+        Nan::Set(description, Nan::New("type").ToLocalChecked(), Nan::New(type).ToLocalChecked());
+        Nan::Set(description, Nan::New("sdp").ToLocalChecked(), Nan::New(sdp).ToLocalChecked());
+        result = description;
+      }
+    }
   }
 
   TRACE_END;
-#if NODE_MAJOR_VERSION == 0
-  info.GetReturnValue().Set(Nan::New(value));
-#else
-  info.GetReturnValue().Set(value);
-#endif
+  info.GetReturnValue().Set(result);
 }
 
 NAN_GETTER(PeerConnection::GetSignalingState) {
   TRACE_CALL;
+  (void) property;
 
-  PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto state = self->_jinglePeerConnection
+      ? self->_jinglePeerConnection->signaling_state()
+      : SignalingState::kClosed;
 
-  webrtc::PeerConnectionInterface::SignalingState state;
-
-  if (self->_jinglePeerConnection != nullptr) {
-    state = self->_jinglePeerConnection->signaling_state();
-  } else {
-    state = webrtc::PeerConnectionInterface::kClosed;
+  Local<String> value;
+  switch (state) {
+    case SignalingState::kStable:
+      value = Nan::New("stable").ToLocalChecked();
+      break;
+    case SignalingState::kHaveLocalOffer:
+      value = Nan::New("have-local-offer").ToLocalChecked();
+      break;
+    case SignalingState::kHaveRemoteOffer:
+      value = Nan::New("have-remote-offer").ToLocalChecked();
+      break;
+    case SignalingState::kHaveLocalPrAnswer:
+      value = Nan::New("have-local-pranswer").ToLocalChecked();
+      break;
+    case SignalingState::kHaveRemotePrAnswer:
+      value = Nan::New("have-remote-pranswer").ToLocalChecked();
+      break;
+    case SignalingState::kClosed:
+      value = Nan::New("closed").ToLocalChecked();
+      break;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(Nan::New<Number>(state));
+  info.GetReturnValue().Set(value);
 }
 
 NAN_GETTER(PeerConnection::GetIceConnectionState) {
   TRACE_CALL;
+  (void) property;
 
-  PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto state = self->_jinglePeerConnection
+      ? self->_jinglePeerConnection->ice_connection_state()
+      : IceConnectionState::kIceConnectionClosed;
 
-  webrtc::PeerConnectionInterface::IceConnectionState state;
-
-  if (self->_jinglePeerConnection != nullptr) {
-    state = self->_jinglePeerConnection->ice_connection_state();
-  } else {
-    state = webrtc::PeerConnectionInterface::kIceConnectionClosed;
+  Local<Value> value;
+  switch (state) {
+    case IceConnectionState::kIceConnectionChecking:
+      value = Nan::New("checking").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionClosed:
+      value = Nan::New("closed").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionCompleted:
+      value = Nan::New("completed").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionConnected:
+      value = Nan::New("connected").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionDisconnected:
+      value = Nan::New("disconnected").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionFailed:
+      value = Nan::New("failed").ToLocalChecked();
+      break;
+    case IceConnectionState::kIceConnectionMax:
+      TRACE_END;
+      return Nan::ThrowTypeError("WebRTC\'s RTCPeerConnection has an ICE connection state \"max\", but I have no idea"
+              "what this means. If you see this error, file a bug on https://github.com/js-platform/node-webrtc");
+    case IceConnectionState::kIceConnectionNew:
+      value = Nan::New("new").ToLocalChecked();
+      break;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(Nan::New<Number>(state));
+  info.GetReturnValue().Set(value);
 }
 
 NAN_GETTER(PeerConnection::GetIceGatheringState) {
   TRACE_CALL;
+  (void) property;
 
-  PeerConnection* self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
+  auto state = self->_jinglePeerConnection
+      ? self->_jinglePeerConnection->ice_gathering_state()
+      : IceGatheringState::kIceGatheringComplete;
 
-  webrtc::PeerConnectionInterface::IceGatheringState state;
-
-  if (self->_jinglePeerConnection != nullptr) {
-    state = self->_jinglePeerConnection->ice_gathering_state();
-  } else {
-    state = webrtc::PeerConnectionInterface::kIceGatheringComplete;
+  Local<Value> value;
+  switch (state) {
+    case IceGatheringState::kIceGatheringNew:
+      value = Nan::New("new").ToLocalChecked();
+      break;
+    case IceGatheringState::kIceGatheringGathering:
+      value = Nan::New("gathering").ToLocalChecked();
+      break;
+    case IceGatheringState::kIceGatheringComplete:
+      value = Nan::New("complete").ToLocalChecked();
+      break;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(Nan::New<Number>(static_cast<uint32_t>(state)));
+  info.GetReturnValue().Set(value);
 }
 
 NAN_SETTER(PeerConnection::ReadOnly) {

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -122,7 +122,7 @@ class PeerConnection
         ICE_GATHERING_STATE_CHANGE
   };
 
-  explicit PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList);
+  explicit PeerConnection(webrtc::PeerConnectionInterface::RTCConfiguration configuration);
   ~PeerConnection();
 
   //

--- a/test/closing-data-channel.js
+++ b/test/closing-data-channel.js
@@ -6,7 +6,7 @@ var RTCPeerConnection = require('..').RTCPeerConnection;
 test('make sure closing an RTCDataChannel after an RTCPeerConnection has been garbage collected doesn\'t segfault', function(t) {
   var dc = (function() {
     var pc = new RTCPeerConnection();
-    var dc = pc.createDataChannel();
+    var dc = pc.createDataChannel('foo');
     pc.close();
     return dc;
   })();


### PR DESCRIPTION
Extracted from #332. Idea is to make converting to/from C++ more declarative and extensible going forward by borrowing some functional programming concepts. For example, a relatively complicated dictionary, like RTCConfiguration, can be handled as

```cpp
Validation<RTCConfiguration> Converter<Local<Value>, RTCConfiguration>::Convert(const Local<Value> value) {
  return From<Local<Object>>(value).FlatMap<RTCConfiguration>(
      [](const Local<Object> object) {
        return curry(CreateRTCConfiguration)
            % GetOptional<std::vector<IceServer>>(object, "iceServers", std::vector<IceServer>())
            * GetOptional<IceTransportsType>(object, "iceTransportPolicy", IceTransportsType::kAll)
            * GetOptional<BundlePolicy>(object, "bundlePolicy", BundlePolicy::kBundlePolicyBalanced)
            * GetOptional<RtcpMuxPolicy>(object, "rtcpMuxPolicy", RtcpMuxPolicy::kRtcpMuxPolicyRequire)
            * GetOptional<std::string>(object, "peerIdentity")
            * GetOptional<std::vector<Local<Object>>>(object, "certificates")
            // TODO(mroberts): Implement EnforceRange and change to uint8_t.
            * GetOptional<uint32_t>(object, "iceCandidatePoolSize", 0);
      });
}
```