### PR TITLE
Add converters for C++ → JavaScript

### DIFF
--- a/lib/datachannel.js
+++ b/lib/datachannel.js
@@ -47,14 +47,10 @@ function RTCDataChannel(internalDC) {
     },
     binaryType: {
       get: function getBinaryType() {
-        var type = internalDC.binaryType;
-        return this.BinaryTypes[type];
+        return internalDC.binaryType;
       },
-      set: function(type) {
-        var typenum = this.BinaryTypes.indexOf(type);
-        if (typenum >= 0) {
-          internalDC.binaryType = typenum;
-        }
+      set: function(binaryType) {
+        internalDC.binaryType = binaryType;
       }
     }
   });
@@ -67,10 +63,5 @@ function RTCDataChannel(internalDC) {
     internalDC.close();
   };
 }
-
-RTCDataChannel.prototype.BinaryTypes = [
-  'blob',  // Note: not sure what to do about this, since node doesn't have a Blob API
-  'arraybuffer'
-];
 
 module.exports = RTCDataChannel;

--- a/lib/datachannel.js
+++ b/lib/datachannel.js
@@ -17,9 +17,8 @@ function RTCDataChannel(internalDC) {
     self.dispatchEvent(new RTCDataChannelMessageEvent(data));
   };
 
-  internalDC.onstatechange = function onstatechange(state) {
-    state = self.RTCDataStates[state];
-    switch (state) {
+  internalDC.onstatechange = function onstatechange() {
+    switch (this.readyState) {
       case 'open':
         self.dispatchEvent({ type: 'open' });
         break;
@@ -43,8 +42,7 @@ function RTCDataChannel(internalDC) {
     },
     readyState: {
       get: function getReadyState() {
-        var state = internalDC.readyState;
-        return this.RTCDataStates[state];
+        return internalDC.readyState;
       }
     },
     binaryType: {
@@ -69,13 +67,6 @@ function RTCDataChannel(internalDC) {
     internalDC.close();
   };
 }
-
-RTCDataChannel.prototype.RTCDataStates = [
-  'connecting',
-  'open',
-  'closing',
-  'closed'
-];
 
 RTCDataChannel.prototype.BinaryTypes = [
   'blob',  // Note: not sure what to do about this, since node doesn't have a Blob API

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -338,6 +338,10 @@ function RTCPeerConnection(configuration, constraints) {
     }
   };
 
+  this.getConfiguration = function getConfiguration() {
+    return pc.getConfiguration();
+  };
+
   this.getStats = function getStats(onSuccess, onFailure) {
     pc.getStats(function(internalRTCStatsResponse) {
       onSuccess(new RTCStatsResponse(internalRTCStatsResponse));

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -72,13 +72,8 @@ function RTCPeerConnection(configuration, constraints) {
     executeNext();
   };
 
-  pc.onicecandidate = function onicecandidate(candidate, sdpMid, sdpMLineIndex) {
-    var icecandidate = new RTCIceCandidate({
-      candidate: candidate,
-      sdpMid: sdpMid,
-      sdpMLineIndex: sdpMLineIndex
-    });
-
+  pc.onicecandidate = function onicecandidate(candidate) {
+    var icecandidate = new RTCIceCandidate(candidate);
     self.dispatchEvent(new RTCPeerConnectionIceEvent('icecandidate', { candidate: icecandidate }));
   };
 

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -9,6 +9,7 @@
 
 #include "src/converters/object.h"
 
+using Nan::EscapableHandleScope;
 using node_webrtc::Converter;
 using node_webrtc::Either;
 using node_webrtc::ExtendedRTCConfiguration;
@@ -33,12 +34,15 @@ using webrtc::IceCandidateInterface;
 using webrtc::SessionDescriptionInterface;
 
 using BundlePolicy = webrtc::PeerConnectionInterface::BundlePolicy;
+using IceConnectionState = webrtc::PeerConnectionInterface::IceConnectionState;
+using IceGatheringState = webrtc::PeerConnectionInterface::IceGatheringState;
 using IceServer = webrtc::PeerConnectionInterface::IceServer;
 using IceTransportsType = webrtc::PeerConnectionInterface::IceTransportsType;
 using RTCConfiguration = webrtc::PeerConnectionInterface::RTCConfiguration;
 using RTCOfferAnswerOptions = webrtc::PeerConnectionInterface::RTCOfferAnswerOptions;
 using RtcpMuxPolicy = webrtc::PeerConnectionInterface::RtcpMuxPolicy;
 using SdpParseError = webrtc::SdpParseError;
+using SignalingState = webrtc::PeerConnectionInterface::SignalingState ;
 
 static RTCOAuthCredential CreateRTCOAuthCredential(
     const std::string& macKey,
@@ -377,3 +381,57 @@ Validation<DataChannelInit> Converter<Local<Value>, DataChannelInit>::Convert(co
             * GetOptional<RTCPriorityType>(object, "priority", kLow);
       });
 }
+
+Validation<Local<Value>> Converter<SignalingState, Local<Value>>::Convert(const SignalingState state) {
+  EscapableHandleScope scope;
+  switch (state) {
+    case SignalingState::kStable:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("stable").ToLocalChecked()));
+    case SignalingState::kHaveLocalOffer:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("have-local-offer").ToLocalChecked()));
+    case SignalingState::kHaveRemoteOffer:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("have-remote-offer").ToLocalChecked()));
+    case SignalingState::kHaveLocalPrAnswer:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("have-local-pranswer").ToLocalChecked()));
+    case SignalingState::kHaveRemotePrAnswer:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("have-remote-pranswer").ToLocalChecked()));
+    case SignalingState::kClosed:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("closed").ToLocalChecked()));
+  }
+};
+
+Validation<Local<Value>> Converter<IceGatheringState, Local<Value>>::Convert(const IceGatheringState state) {
+  EscapableHandleScope scope;
+  switch (state) {
+    case IceGatheringState::kIceGatheringNew:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("new").ToLocalChecked()));
+    case IceGatheringState::kIceGatheringGathering:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("gathering").ToLocalChecked()));
+    case IceGatheringState::kIceGatheringComplete:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("complete").ToLocalChecked()));
+  }
+};
+
+Validation<Local<Value>> Converter<IceConnectionState, Local<Value>>::Convert(const IceConnectionState state) {
+  EscapableHandleScope scope;
+  switch (state) {
+    case IceConnectionState::kIceConnectionChecking:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("checking").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionClosed:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("closed").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionCompleted:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("completed").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionConnected:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("connected").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionDisconnected:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("disconnected").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionFailed:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("failed").ToLocalChecked()));
+    case IceConnectionState::kIceConnectionMax:
+      return Validation<Local<Value>>::Invalid(
+              "WebRTC\'s RTCPeerConnection has an ICE connection state \"max\", but I have no idea"
+              "what this means. If you see this error, file a bug on https://github.com/js-platform/node-webrtc");
+    case IceConnectionState::kIceConnectionNew:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("new").ToLocalChecked()));
+  }
+};

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -34,6 +34,7 @@ using webrtc::IceCandidateInterface;
 using webrtc::SessionDescriptionInterface;
 
 using BundlePolicy = webrtc::PeerConnectionInterface::BundlePolicy;
+using DataState = webrtc::DataChannelInterface::DataState;
 using IceConnectionState = webrtc::PeerConnectionInterface::IceConnectionState;
 using IceGatheringState = webrtc::PeerConnectionInterface::IceGatheringState;
 using IceServer = webrtc::PeerConnectionInterface::IceServer;
@@ -433,5 +434,19 @@ Validation<Local<Value>> Converter<IceConnectionState, Local<Value>>::Convert(co
               "what this means. If you see this error, file a bug on https://github.com/js-platform/node-webrtc");
     case IceConnectionState::kIceConnectionNew:
       return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("new").ToLocalChecked()));
+  }
+};
+
+Validation<Local<Value>> Converter<DataState, Local<Value>>::Convert(const DataState state) {
+  EscapableHandleScope scope;
+  switch (state) {
+    case DataState::kClosed:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("closed").ToLocalChecked()));
+    case DataState::kClosing:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("closing").ToLocalChecked()));
+    case DataState::kConnecting:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("connecting").ToLocalChecked()));
+    case DataState::kOpen:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("open").ToLocalChecked()));
   }
 };

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -10,6 +10,7 @@
 #include "src/converters/object.h"
 
 using Nan::EscapableHandleScope;
+using node_webrtc::BinaryType;
 using node_webrtc::Converter;
 using node_webrtc::Either;
 using node_webrtc::ExtendedRTCConfiguration;
@@ -449,4 +450,27 @@ Validation<Local<Value>> Converter<DataState, Local<Value>>::Convert(const DataS
     case DataState::kOpen:
       return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("open").ToLocalChecked()));
   }
+};
+
+Validation<Local<Value>> Converter<BinaryType, Local<Value>>::Convert(const BinaryType binaryType) {
+  EscapableHandleScope scope;
+  switch (binaryType) {
+    case BinaryType::kArrayBuffer:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("arraybuffer").ToLocalChecked()));
+    case BinaryType::kBlob:
+      return Validation<Local<Value>>::Valid(scope.Escape(Nan::New("blob").ToLocalChecked()));
+  }
+};
+
+Validation<BinaryType> Converter<Local<Value>, BinaryType>::Convert(const Local<Value> value) {
+  return From<std::string>(value).FlatMap<BinaryType>(
+      [](const std::string string) {
+          if (string == "blob") {
+            return Validation<BinaryType>::Invalid(R"("blob" is not supported at this time; file a bug on https://github.com/js-platform/node-webrtc)");
+          } else if (string == "arraybuffer") {
+            return Validation<BinaryType>::Valid(BinaryType::kArrayBuffer);
+          } else {
+            return Validation<BinaryType>::Invalid(R"(Expected "blob" or "arraybuffer")");
+          }
+      });
 };

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -173,6 +173,18 @@ Validation<UnsignedShortRange> Converter<Local<Value>, UnsignedShortRange>::Conv
       });
 };
 
+Validation<Local<Value>> Converter<UnsignedShortRange, Local<Value>>::Convert(const UnsignedShortRange value) {
+  EscapableHandleScope scope;
+  auto object = Nan::New<Object>();
+  if (value.min.IsJust()) {
+    object->Set(Nan::New("min").ToLocalChecked(), Nan::New(value.min.UnsafeFromJust()));
+  }
+  if (value.max.IsJust()) {
+    object->Set(Nan::New("max").ToLocalChecked(), Nan::New(value.max.UnsafeFromJust()));
+  }
+  return Validation<Local<Value>>::Valid(scope.Escape(object));
+};
+
 static RTCConfiguration CreateRTCConfiguration(
     const std::vector<IceServer>& iceServers,
     const IceTransportsType iceTransportsPolicy,

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -312,6 +312,25 @@ Validation<SessionDescriptionInterface*> Converter<Local<Value>, SessionDescript
       });
 }
 
+Validation<Local<Value>> Converter<const SessionDescriptionInterface*, Local<Value>>::Convert(const SessionDescriptionInterface* value) {
+  EscapableHandleScope scope;
+
+  if (!value) {
+    return Validation<Local<Value>>::Invalid("RTCSessionDescription is null");
+  }
+
+  std::string sdp;
+  if (!value->ToString(&sdp)) {
+    return Validation<Local<Value>>::Invalid("Failed to print the SDP. This is pretty weird. File a bug on https://github.com/js-platform/node-webrtc");
+  }
+
+  auto object = Nan::New<Object>();
+  object->Set(Nan::New("sdp").ToLocalChecked(), Nan::New(sdp).ToLocalChecked());
+  object->Set(Nan::New("type").ToLocalChecked(), Nan::New(value->type()).ToLocalChecked());
+
+  return Validation<Local<Value>>::Valid(scope.Escape(object));
+};
+
 static Validation<IceCandidateInterface*> CreateIceCandidateInterface(
     const std::string& candidate,
     const std::string& sdpMid,

--- a/src/converters/webrtc.cc
+++ b/src/converters/webrtc.cc
@@ -355,6 +355,26 @@ Validation<IceCandidateInterface*> Converter<Local<Value>, IceCandidateInterface
       });
 }
 
+Validation<Local<Value>> Converter<const IceCandidateInterface*, Local<Value>>::Convert(const IceCandidateInterface* value) {
+  EscapableHandleScope scope;
+
+  if (!value) {
+    return Validation<Local<Value>>::Invalid("RTCIceCandidate is null");
+  }
+
+  std::string candidate;
+  if (!value->ToString(&candidate)) {
+    return Validation<Local<Value>>::Invalid("Failed to print the candidate string. This is pretty weird. File a bug on https://github.com/js-platform/node-webrtc");
+  }
+
+  auto object = Nan::New<Object>();
+  object->Set(Nan::New("candidate").ToLocalChecked(), Nan::New(candidate).ToLocalChecked());
+  object->Set(Nan::New("sdpMid").ToLocalChecked(), Nan::New(value->sdp_mid()).ToLocalChecked());
+  object->Set(Nan::New("sdpMLineIndex").ToLocalChecked(), Nan::New(value->sdp_mline_index()));
+
+  return Validation<Local<Value>>::Valid(scope.Escape(object));
+};
+
 Validation<RTCPriorityType> Converter<Local<Value>, RTCPriorityType>::Convert(const Local<Value> value) {
   return From<std::string>(value).FlatMap<RTCPriorityType>(
       [](const std::string string) {

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -316,6 +316,52 @@ struct Converter<v8::Local<v8::Value>, webrtc::DataChannelInit> {
   static Validation<webrtc::DataChannelInit> Convert(v8::Local<v8::Value> value);
 };
 
+/*
+ * enum RTCSignalingState {
+ *   "stable",
+ *   "have-local-offer",
+ *   "have-remote-offer",
+ *   "have-local-pranswer",
+ *   "have-remote-pranswer",
+ *   "closed"
+ * }
+ */
+
+template <>
+struct Converter<webrtc::PeerConnectionInterface::SignalingState, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::SignalingState value);
+};
+
+/*
+ * enum RTCIceGatheringState {
+ *   "new",
+ *   "gathering",
+ *   "complete"
+ * }
+ */
+
+template <>
+struct Converter<webrtc::PeerConnectionInterface::IceGatheringState, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::IceGatheringState value);
+};
+
+/*
+ * enum RTCIceConnectionState {
+ *   "new",
+ *   "checking",
+ *   "connected",
+ *   "completed",
+ *   "disconnected",
+ *   "failed",
+ *   "closed"
+ * }
+ */
+
+template <>
+struct Converter<webrtc::PeerConnectionInterface::IceConnectionState, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::IceConnectionState value);
+};
+
 }  // namespace node_webrtc
 
 #endif  // SRC_CONVERTERS_WEBRTC_H_

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -362,6 +362,20 @@ struct Converter<webrtc::PeerConnectionInterface::IceConnectionState, v8::Local<
   static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::IceConnectionState value);
 };
 
+/*
+ * enum RTCDataChannelState {
+ *   "connecting",
+ *   "open",
+ *   "closing",
+ *   "closed"
+ * }
+ */
+
+template <>
+struct Converter<webrtc::DataChannelInterface::DataState, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::DataChannelInterface::DataState value);
+};
+
 }  // namespace node_webrtc
 
 #endif  // SRC_CONVERTERS_WEBRTC_H_

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -153,6 +153,11 @@ struct Converter<v8::Local<v8::Value>, UnsignedShortRange> {
   static Validation<UnsignedShortRange> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<UnsignedShortRange, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(UnsignedShortRange value);
+};
+
 /*
  * dictionary RTCConfiguration {
  *   sequence<RTCIceServer>   iceServers;

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -87,6 +87,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::IceTrans
   static Validation<webrtc::PeerConnectionInterface::IceTransportsType> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<webrtc::PeerConnectionInterface::IceTransportsType, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::IceTransportsType value);
+};
+
 /*
  * enum RTCBundlePolicy {
  *   "balanced",
@@ -100,6 +105,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::BundlePo
   static Validation<webrtc::PeerConnectionInterface::BundlePolicy> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<webrtc::PeerConnectionInterface::BundlePolicy, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::BundlePolicy value);
+};
+
 /*
  * enum RTCRtcpMuxPolicy {
  *   // At risk due to lack of implementers' interest.
@@ -111,6 +121,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::BundlePo
 template <>
 struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::RtcpMuxPolicy> {
   static Validation<webrtc::PeerConnectionInterface::RtcpMuxPolicy> Convert(v8::Local<v8::Value> value);
+};
+
+template <>
+struct Converter<webrtc::PeerConnectionInterface::RtcpMuxPolicy, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::RtcpMuxPolicy value);
 };
 
 /*
@@ -144,8 +159,8 @@ struct Converter<v8::Local<v8::Value>, RTCDtlsFingerprint> {
 struct UnsignedShortRange {
   UnsignedShortRange(): min(Maybe<uint16_t>::Nothing()), max(Maybe<uint16_t>::Nothing()) {}
   UnsignedShortRange(const Maybe<uint16_t> min, const Maybe<uint16_t> max): min(min), max(max) {}
-  const Maybe<uint16_t> min;
-  const Maybe<uint16_t> max;
+  Maybe<uint16_t> min;
+  Maybe<uint16_t> max;
 };
 
 template <>
@@ -180,13 +195,18 @@ struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::RTCConfi
 struct ExtendedRTCConfiguration {
   ExtendedRTCConfiguration(): configuration(webrtc::PeerConnectionInterface::RTCConfiguration()), portRange(UnsignedShortRange()) {}
   ExtendedRTCConfiguration(const webrtc::PeerConnectionInterface::RTCConfiguration configuration, const UnsignedShortRange portRange): configuration(configuration), portRange(portRange) {}
-  const webrtc::PeerConnectionInterface::RTCConfiguration configuration;
-  const UnsignedShortRange portRange;
+  webrtc::PeerConnectionInterface::RTCConfiguration configuration;
+  UnsignedShortRange portRange;
 };
 
 template <>
 struct Converter<v8::Local<v8::Value>, ExtendedRTCConfiguration> {
   static Validation<ExtendedRTCConfiguration> Convert(v8::Local<v8::Value> value);
+};
+
+template <>
+struct Converter<ExtendedRTCConfiguration, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(ExtendedRTCConfiguration value);
 };
 
 /*

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -376,6 +376,28 @@ struct Converter<webrtc::DataChannelInterface::DataState, v8::Local<v8::Value>> 
   static Validation<v8::Local<v8::Value>> Convert(webrtc::DataChannelInterface::DataState value);
 };
 
+/*
+ * enum BinaryType {
+ *   "blob",
+ *   "arraybuffer"
+ * }
+ */
+
+enum BinaryType {
+  kBlob,
+  kArrayBuffer,
+};
+
+template <>
+struct Converter<BinaryType, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(BinaryType value);
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, BinaryType> {
+  static Validation<BinaryType> Convert(v8::Local<v8::Value> value);
+};
+
 }  // namespace node_webrtc
 
 #endif  // SRC_CONVERTERS_WEBRTC_H_

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -263,6 +263,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::SessionDescriptionInterface*> {
   static Validation<webrtc::SessionDescriptionInterface*> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<const webrtc::SessionDescriptionInterface*, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(const webrtc::SessionDescriptionInterface* value);
+};
+
 /*
  * dictionary RTCIceCandidateInit {
  *     DOMString       candidate = "";

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -282,6 +282,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::IceCandidateInterface*> {
   static Validation<webrtc::IceCandidateInterface*> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<const webrtc::IceCandidateInterface*, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(const webrtc::IceCandidateInterface* value);
+};
+
 /*
  * enum RTCPriorityType {
  *   "very-low",

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -75,6 +75,11 @@ struct Converter<v8::Local<v8::Value>, webrtc::PeerConnectionInterface::IceServe
   static Validation<webrtc::PeerConnectionInterface::IceServer> Convert(v8::Local<v8::Value> value);
 };
 
+template <>
+struct Converter<webrtc::PeerConnectionInterface::IceServer, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(webrtc::PeerConnectionInterface::IceServer value);
+};
+
 /*
  * enum RTCIceTransportPolicy {
  *   "relay",

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -10,6 +10,8 @@
 #include <stdint.h>
 
 #include "common.h"
+#include "converters.h"
+#include "converters/webrtc.h"
 
 using node_webrtc::DataChannel;
 using node_webrtc::DataChannelObserver;
@@ -335,8 +337,16 @@ NAN_GETTER(DataChannel::GetReadyState) {
       ? self->_jingleDataChannel->state()
       : webrtc::DataChannelInterface::kClosed;
 
+  auto maybeStateString = From<Local<Value>>(state);
+  if (maybeStateString.IsInvalid()) {
+    auto error = maybeStateString.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
+  }
+
   TRACE_END;
-  info.GetReturnValue().Set(Nan::New<Number>(static_cast<uint32_t>(state)));
+  info.GetReturnValue().Set(maybeStateString.UnsafeFromValid());
 }
 
 NAN_GETTER(DataChannel::GetBinaryType) {

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -74,7 +74,7 @@ void DataChannelObserver::QueueEvent(DataChannel::AsyncEventType type, void* dat
 
 DataChannel::DataChannel(node_webrtc::DataChannelObserver* observer)
   : loop(uv_default_loop()),
-    _binaryType(DataChannel::ARRAY_BUFFER) {
+    _binaryType(BinaryType::kArrayBuffer) {
   uv_mutex_init(&lock);
   uv_async_init(loop, &async, reinterpret_cast<uv_async_cb>(Run));
 
@@ -354,15 +354,32 @@ NAN_GETTER(DataChannel::GetBinaryType) {
 
   DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.Holder());
 
+  auto maybeBinaryType = From<Local<Value>>(self->_binaryType);
+  if (maybeBinaryType.IsInvalid()) {
+    auto error = maybeBinaryType.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
+  }
+
   TRACE_END;
-  info.GetReturnValue().Set(Nan::New<Number>(static_cast<uint32_t>(self->_binaryType)));
+  info.GetReturnValue().Set(maybeBinaryType.UnsafeFromValid());
 }
 
 NAN_SETTER(DataChannel::SetBinaryType) {
   TRACE_CALL;
 
   DataChannel* self = Nan::ObjectWrap::Unwrap<DataChannel>(info.Holder());
-  self->_binaryType = static_cast<BinaryType>(value->Uint32Value());
+
+  auto maybeBinaryType = From<BinaryType>(value);
+  if (maybeBinaryType.IsInvalid()) {
+    auto error = maybeBinaryType.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
+  }
+
+  self->_binaryType = maybeBinaryType.UnsafeFromValid();
 
   TRACE_END;
 }

--- a/src/datachannel.h
+++ b/src/datachannel.h
@@ -21,6 +21,7 @@
 #include "webrtc/base/buffer.h"
 #include "webrtc/base/scoped_ref_ptr.h"
 
+#include "converters/webrtc.h"
 #include "peerconnectionfactory.h"
 
 namespace node_webrtc {
@@ -63,11 +64,6 @@ class DataChannel
     MESSAGE = 0x1 << 0,  // 1
     ERROR = 0x1 << 1,  // 2
     STATE = 0x1 << 2,  // 4
-  };
-
-  enum BinaryType {
-    BLOB = 0x0,
-    ARRAY_BUFFER = 0x1
   };
 
   explicit DataChannel(node_webrtc::DataChannelObserver* observer);
@@ -114,7 +110,7 @@ class DataChannel
 
   std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;
   rtc::scoped_refptr<webrtc::DataChannelInterface> _jingleDataChannel;
-  BinaryType _binaryType;
+  node_webrtc::BinaryType _binaryType;
 
 #if NODE_MODULE_VERSION < 0x000C
   static Nan::Persistent<v8::Function> ArrayBufferConstructor;

--- a/src/functional/maybe.h
+++ b/src/functional/maybe.h
@@ -123,8 +123,8 @@ class Maybe {
   }
 
  private:
-  const bool _is_just;
-  const T _value;
+  bool _is_just;
+  T _value;
 };
 
 }  // namespace node_webrtc

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -511,17 +511,15 @@ NAN_GETTER(PeerConnection::GetLocalDescription) {
   auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
   Local<Value> result = Nan::Null();
-  if (self->_jinglePeerConnection) {
-    if (auto _description = self->_jinglePeerConnection->local_description()) {
-      std::string sdp;
-      if (_description->ToString(&sdp)) {
-        auto type = _description->type();
-        Local<Object> description = Nan::New<Object>();
-        Nan::Set(description, Nan::New("type").ToLocalChecked(), Nan::New(type).ToLocalChecked());
-        Nan::Set(description, Nan::New("sdp").ToLocalChecked(), Nan::New(sdp).ToLocalChecked());
-        result = description;
-      }
+  if (self->_jinglePeerConnection && self->_jinglePeerConnection->local_description()) {
+    auto maybeDescription = From<Local<Value>>(self->_jinglePeerConnection->local_description());
+    if (maybeDescription.IsInvalid()) {
+      auto error = maybeDescription.ToErrors()[0];
+      TRACE_END;
+      Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+      return;
     }
+    result = maybeDescription.UnsafeFromValid();
   }
 
   TRACE_END;
@@ -536,17 +534,15 @@ NAN_GETTER(PeerConnection::GetRemoteDescription) {
   auto self = Nan::ObjectWrap::Unwrap<PeerConnection>(info.Holder());
 
   Local<Value> result = Nan::Null();
-  if (self->_jinglePeerConnection) {
-    if (auto _description = self->_jinglePeerConnection->remote_description()) {
-      std::string sdp;
-      if (_description->ToString(&sdp)) {
-        auto type = _description->type();
-        Local<Object> description = Nan::New<Object>();
-        Nan::Set(description, Nan::New("type").ToLocalChecked(), Nan::New(type).ToLocalChecked());
-        Nan::Set(description, Nan::New("sdp").ToLocalChecked(), Nan::New(sdp).ToLocalChecked());
-        result = description;
-      }
+  if (self->_jinglePeerConnection && self->_jinglePeerConnection->remote_description()) {
+    auto maybeDescription = From<Local<Value>>(self->_jinglePeerConnection->remote_description());
+    if (maybeDescription.IsInvalid()) {
+      auto error = maybeDescription.ToErrors()[0];
+      TRACE_END;
+      Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+      return;
     }
+    result = maybeDescription.UnsafeFromValid();
   }
 
   TRACE_END;

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -562,30 +562,16 @@ NAN_GETTER(PeerConnection::GetSignalingState) {
       ? self->_jinglePeerConnection->signaling_state()
       : SignalingState::kClosed;
 
-  Local<String> value;
-  switch (state) {
-    case SignalingState::kStable:
-      value = Nan::New("stable").ToLocalChecked();
-      break;
-    case SignalingState::kHaveLocalOffer:
-      value = Nan::New("have-local-offer").ToLocalChecked();
-      break;
-    case SignalingState::kHaveRemoteOffer:
-      value = Nan::New("have-remote-offer").ToLocalChecked();
-      break;
-    case SignalingState::kHaveLocalPrAnswer:
-      value = Nan::New("have-local-pranswer").ToLocalChecked();
-      break;
-    case SignalingState::kHaveRemotePrAnswer:
-      value = Nan::New("have-remote-pranswer").ToLocalChecked();
-      break;
-    case SignalingState::kClosed:
-      value = Nan::New("closed").ToLocalChecked();
-      break;
+  auto maybeStateString = From<Local<Value>>(state);
+  if (maybeStateString.IsInvalid()) {
+    auto error = maybeStateString.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(value);
+  info.GetReturnValue().Set(maybeStateString.UnsafeFromValid());
 }
 
 NAN_GETTER(PeerConnection::GetIceConnectionState) {
@@ -597,37 +583,16 @@ NAN_GETTER(PeerConnection::GetIceConnectionState) {
       ? self->_jinglePeerConnection->ice_connection_state()
       : IceConnectionState::kIceConnectionClosed;
 
-  Local<Value> value;
-  switch (state) {
-    case IceConnectionState::kIceConnectionChecking:
-      value = Nan::New("checking").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionClosed:
-      value = Nan::New("closed").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionCompleted:
-      value = Nan::New("completed").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionConnected:
-      value = Nan::New("connected").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionDisconnected:
-      value = Nan::New("disconnected").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionFailed:
-      value = Nan::New("failed").ToLocalChecked();
-      break;
-    case IceConnectionState::kIceConnectionMax:
-      TRACE_END;
-      return Nan::ThrowTypeError("WebRTC\'s RTCPeerConnection has an ICE connection state \"max\", but I have no idea"
-              "what this means. If you see this error, file a bug on https://github.com/js-platform/node-webrtc");
-    case IceConnectionState::kIceConnectionNew:
-      value = Nan::New("new").ToLocalChecked();
-      break;
+  auto maybeStateString = From<Local<Value>>(state);
+  if (maybeStateString.IsInvalid()) {
+    auto error = maybeStateString.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(value);
+  info.GetReturnValue().Set(maybeStateString.UnsafeFromValid());
 }
 
 NAN_GETTER(PeerConnection::GetIceGatheringState) {
@@ -639,21 +604,16 @@ NAN_GETTER(PeerConnection::GetIceGatheringState) {
       ? self->_jinglePeerConnection->ice_gathering_state()
       : IceGatheringState::kIceGatheringComplete;
 
-  Local<Value> value;
-  switch (state) {
-    case IceGatheringState::kIceGatheringNew:
-      value = Nan::New("new").ToLocalChecked();
-      break;
-    case IceGatheringState::kIceGatheringGathering:
-      value = Nan::New("gathering").ToLocalChecked();
-      break;
-    case IceGatheringState::kIceGatheringComplete:
-      value = Nan::New("complete").ToLocalChecked();
-      break;
+  auto maybeStateString = From<Local<Value>>(state);
+  if (maybeStateString.IsInvalid()) {
+    auto error = maybeStateString.ToErrors()[0];
+    TRACE_END;
+    Nan::ThrowTypeError(Nan::New(error).ToLocalChecked());
+    return;
   }
 
   TRACE_END;
-  info.GetReturnValue().Set(value);
+  info.GetReturnValue().Set(maybeStateString.UnsafeFromValid());
 }
 
 NAN_SETTER(PeerConnection::ReadOnly) {

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -173,6 +173,7 @@ class PeerConnection
   static NAN_METHOD(AddStream);
   static NAN_METHOD(RemoveStream);
   */
+  static NAN_METHOD(GetConfiguration);
   static NAN_METHOD(GetStats);
   static NAN_METHOD(Close);
 
@@ -205,6 +206,8 @@ class PeerConnection
   rtc::scoped_refptr<SetRemoteDescriptionObserver> _setRemoteDescriptionObserver;
 
   webrtc::AudioDeviceModule* _audioDeviceModule;
+  UnsignedShortRange _port_range;
+  ExtendedRTCConfiguration _cached_configuration;
   rtc::scoped_refptr<webrtc::PeerConnectionInterface> _jinglePeerConnection;
 
   std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;

--- a/test/get-configuration.js
+++ b/test/get-configuration.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var test = require('tape');
+
+var RTCPeerConnection = require('..').RTCPeerConnection;
+
+test('getConfiguration', function(t) {
+  var defaultConfiguration = {
+    iceServers: [],
+    iceTransportPolicy: 'all',
+    bundlePolicy: 'balanced',
+    rtcpMuxPolicy: 'require',
+    iceCandidatePoolSize: 0,
+    portRange: {}
+  };
+
+  t.test('before calling close, with defaults', function(t) {
+    var pc = new RTCPeerConnection();
+    var actualConfiguration = pc.getConfiguration();
+    pc.close();
+    testConfiguration(t, actualConfiguration, defaultConfiguration);
+    t.end();
+  });
+
+  t.test('after calling close, with defaults', function(t) {
+    var pc = new RTCPeerConnection();
+    pc.close();
+    var actualConfiguration = pc.getConfiguration();
+    testConfiguration(t, actualConfiguration, defaultConfiguration);
+    t.end();
+  });
+
+  [
+    ['iceServers', [
+      {
+        urls: 'stun:stun1.example.net'
+      },
+      {
+        urls: ['turns:turn.example.org', 'turn:turn.example.net'],
+        username: 'user',
+        credential: 'myPassword',
+        credentialType: 'password'
+      }
+    ]],
+    ['iceTransportPolicy', 'relay'],
+    ['bundlePolicy', 'max-bundle'],
+    ['rtcpMuxPolicy', 'negotiate'],
+    ['iceCandidatePoolSize', 255],
+    ['portRange', { min: 1, max: 2 }]
+  ].forEach(function(pair) {
+    t.test('after setting ' + pair[0], function(t) {
+      var expectedConfiguration = Object.assign({}, defaultConfiguration);
+      expectedConfiguration[pair[0]] = pair[1];
+      var pc = new RTCPeerConnection(expectedConfiguration);
+      pc.close();
+      var actualConfiguration = pc.getConfiguration();
+      testConfiguration(t, actualConfiguration, expectedConfiguration);
+      t.end();
+    });
+  });
+});
+
+function testConfiguration(t, actualConfiguration, expectedConfiguration) {
+  t.deepEqual(actualConfiguration, expectedConfiguration);
+}


### PR DESCRIPTION
#370 added converters for JavaScript → C++. We need additional converters for C++ → JavaScript.

* [x] RTCSignalingState → string
* [x] RTCIceConnectionState → string
* [x] RTCIceGatheringState → string
* [x] RTCDataChannelState → string
* [x] "BinaryType" → string
* [x] string → "BinaryType"
* [x] RTCSessionDescription → object
* [x] RTCIceCandidate → object
* [x] (Extended)RTCConfiguration → object
* [x] RTCIceServer → object

Edit: this PR also adds support for `getConfiguration` and some new RTCConfiguration options, e.g., `iceCandidatePoolSize` :-) (actually, I haven't tested `iceCandidatePoolSize`'s behavior, but at least we thread the value through now).