### PR TITLE
Fix "Assertion `handle->flags & UV_CLOSING' failed."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ New Features
 
   `portRange` cannot be updated by `setConfiguration`.
 
+Bug Fixes
+---------
+
+- Fixed a failed assertion when closing RTCPeerConnection's or RTCDataChannel's
+  event loop (#376).
+
 0.0.67
 ======
 

--- a/src/datachannel.cc
+++ b/src/datachannel.cc
@@ -220,12 +220,15 @@ void DataChannel::Run(uv_async_t* handle, int status) {
   }
 
   if (do_shutdown) {
-    self->async.data = nullptr;
-    self->Unref();
-    uv_close(reinterpret_cast<uv_handle_t*>(&self->async), nullptr);
+    uv_close(reinterpret_cast<uv_handle_t*>(&self->async), reinterpret_cast<uv_close_cb>(DataChannel::Shutdown));
   }
 
   TRACE_END;
+}
+
+void DataChannel::Shutdown(uv_async_t* handle) {
+  auto self = static_cast<DataChannel*>(handle->data);
+  self->Unref();
 }
 
 void DataChannel::OnStateChange() {

--- a/src/datachannel.h
+++ b/src/datachannel.h
@@ -97,6 +97,7 @@ class DataChannel
 
  private:
   static void Run(uv_async_t* handle, int status);
+  static void Shutdown(uv_async_t* handle);
 
   struct AsyncEvent {
     AsyncEventType type;

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -211,12 +211,15 @@ void PeerConnection::Run(uv_async_t* handle, int status) {
   }
 
   if (do_shutdown) {
-    self->async.data = nullptr;
-    self->Unref();
-    uv_close(reinterpret_cast<uv_handle_t*>(handle), nullptr);
+    uv_close(reinterpret_cast<uv_handle_t*>(handle), reinterpret_cast<uv_close_cb>(&PeerConnection::Shutdown));
   }
 
   TRACE_END;
+}
+
+void PeerConnection::Shutdown(uv_async_t* handle) {
+  auto self = static_cast<PeerConnection*>(handle->data);
+  self->Unref();
 }
 
 void PeerConnection::OnError() {

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -189,6 +189,7 @@ class PeerConnection
 
  private:
   static void Run(uv_async_t* handle, int status);
+  static void Shutdown(uv_async_t* handle);
 
   struct AsyncEvent {
     AsyncEventType type;


### PR DESCRIPTION
@nazar-pc please take a look. Commit message below. Note: I removed the part where I set `async.data` to `nullptr` because I don't think it's necessary.

---

When RTCPeerConnection's or RTCDataChannel's event loop is about to close, we
call `Unref` on either object, which signals that they can be deleted. However,
these objects hold onto the `uv_async_t` that we use for sending messages to the
event loop. If the objects are deleted before the event loop closes, we get an
error like the following:

```
node: ../deps/uv/src/unix/core.c:250: uv__finish_close: Assertion `handle->flags
& UV_CLOSING' failed.

Thread 1 "node" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) backtrace
%s%sAssertion `%s' failed.\n%n", assertion=assertion@entry=0x1761717
"handle->flags & UV_CLOSING", file=file@entry=0x17616f5
"../deps/uv/src/unix/core.c", line=line@entry=250,
function=function@entry=0x17619b0 "uv__finish_close") at assert.c:92
& UV_CLOSING", file=0x17616f5 "../deps/uv/src/unix/core.c", line=250,
function=0x17619b0 "uv__finish_close") at assert.c:101
char const* const*) ()
argv=0x7fffffffe458, init=<optimized out>, fini=<optimized out>,
rtld_fini=<optimized out>, stack_end=0x7fffffffe448) at ../csu/libc-start.c:310
```

The fix, then, is to call `Unref` in the `uv_close_cb` instead of before calling
`uv_close`.

Fixes #376