### PR TITLE
Refactor Events, Take 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.2.10",
+    "cross-env": "^5.1.4",
     "eslint": "^4.14.0",
     "express": "^4.16.2",
     "express-browserify": "^1.0.2",
@@ -70,7 +71,7 @@
     "lint": "eslint lib/*.js lib/**/*.js test/*.js test/**/*.js examples/*.js examples/**/*.js karma.conf.js scripts/*.js",
     "pretest": "npm run wpt:init",
     "test": "node test/all.js",
-    "test:bridge": "node scripts/karma.js",
+    "test:bridge": "cross-env BROWSER=chrome node scripts/karma.js && cross-env BROWSER=firefox node scripts/karma.js",
     "wpt:init": "git submodule update --init --recursive",
     "wpt:reset": "rimraf ./test/web-platform-tests/tests && yarn wpt:init",
     "wpt:test": "mocha test/web-platform-tests/run-wpts.js",

--- a/src/create-answer-observer.cc
+++ b/src/create-answer-observer.cc
@@ -15,14 +15,12 @@ using node_webrtc::PeerConnection;
 
 void CreateAnswerObserver::OnSuccess(webrtc::SessionDescriptionInterface* sdp) {
   TRACE_CALL;
-  PeerConnection::SdpEvent* data = new PeerConnection::SdpEvent(sdp);
-  parent->QueueEvent(PeerConnection::CREATE_ANSWER_SUCCESS, static_cast<void*>(data));
+  parent->Dispatch(CreateAnswerSuccessEvent::Create(sdp));
   TRACE_END;
 }
 
 void CreateAnswerObserver::OnFailure(const std::string& msg) {
   TRACE_CALL;
-  PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(msg);
-  parent->QueueEvent(PeerConnection::CREATE_ANSWER_ERROR, static_cast<void*>(data));
+  parent->Dispatch(CreateAnswerErrorEvent::Create(msg));
   TRACE_END;
 }

--- a/src/create-offer-observer.cc
+++ b/src/create-offer-observer.cc
@@ -15,14 +15,12 @@ using node_webrtc::PeerConnection;
 
 void CreateOfferObserver::OnSuccess(webrtc::SessionDescriptionInterface* sdp) {
   TRACE_CALL;
-  PeerConnection::SdpEvent* data = new PeerConnection::SdpEvent(sdp);
-  parent->QueueEvent(PeerConnection::CREATE_OFFER_SUCCESS, static_cast<void*>(data));
+  parent->Dispatch(CreateOfferSuccessEvent::Create(sdp));
   TRACE_END;
 }
 
 void CreateOfferObserver::OnFailure(const std::string& msg) {
   TRACE_CALL;
-  PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(msg);
-  parent->QueueEvent(PeerConnection::CREATE_OFFER_ERROR, static_cast<void*>(data));
+  parent->Dispatch(CreateOfferErrorEvent::Create(msg));
   TRACE_END;
 }

--- a/src/events.cc
+++ b/src/events.cc
@@ -10,10 +10,30 @@
 #include "src/datachannel.h"
 #include "src/peerconnection.h"
 
+using node_webrtc::AddIceCandidateSuccessEvent;
 using node_webrtc::DataChannel;
+using node_webrtc::DataChannelEvent;
 using node_webrtc::DataChannelStateChangeEvent;
 using node_webrtc::ErrorEvent;
+using node_webrtc::GetStatsEvent;
+using node_webrtc::IceConnectionStateChangeEvent;
+using node_webrtc::IceGatheringStateChangeEvent;
+using node_webrtc::IceEvent;
 using node_webrtc::MessageEvent;
+using node_webrtc::NegotiationNeededEvent;
+using node_webrtc::PeerConnection;
+using node_webrtc::SdpEvent;
+using node_webrtc::SetLocalDescriptionSuccessEvent;
+using node_webrtc::SetRemoteDescriptionSuccessEvent;
+using node_webrtc::SignalingStateChangeEvent;
+
+void AddIceCandidateSuccessEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleVoidEvent();
+}
+
+void DataChannelEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleDataChannelEvent(*this);
+}
 
 void DataChannelStateChangeEvent::Dispatch(DataChannel& dataChannel) {
   dataChannel.HandleStateEvent(*this);
@@ -24,6 +44,47 @@ void ErrorEvent<DataChannel>::Dispatch(DataChannel& dataChannel) {
   dataChannel.HandleErrorEvent(*this);
 }
 
+template <>
+void ErrorEvent<PeerConnection>::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleErrorEvent(*this);
+}
+
 void MessageEvent::Dispatch(DataChannel& dataChannel) {
   dataChannel.HandleMessageEvent(*this);
+}
+
+void NegotiationNeededEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleNegotiationNeededEvent(*this);
+}
+
+void GetStatsEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleGetStatsEvent(*this);
+}
+
+void IceEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleIceCandidateEvent(*this);
+}
+
+void IceConnectionStateChangeEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleIceConnectionStateChangeEvent(*this);
+}
+
+void IceGatheringStateChangeEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleIceGatheringStateChangeEvent(*this);
+}
+
+void SdpEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleSdpEvent(*this);
+}
+
+void SetLocalDescriptionSuccessEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleVoidEvent();
+}
+
+void SetRemoteDescriptionSuccessEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleVoidEvent();
+}
+
+void SignalingStateChangeEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleSignalingStateChangeEvent(*this);
 }

--- a/src/set-local-description-observer.cc
+++ b/src/set-local-description-observer.cc
@@ -15,13 +15,12 @@ using node_webrtc::SetLocalDescriptionObserver;
 
 void SetLocalDescriptionObserver::OnSuccess() {
   TRACE_CALL;
-  parent->QueueEvent(PeerConnection::SET_LOCAL_DESCRIPTION_SUCCESS, static_cast<void*>(nullptr));
+  parent->Dispatch(SetLocalDescriptionSuccessEvent::Create());
   TRACE_END;
 }
 
 void SetLocalDescriptionObserver::OnFailure(const std::string& msg) {
   TRACE_CALL;
-  PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(msg);
-  parent->QueueEvent(PeerConnection::SET_LOCAL_DESCRIPTION_ERROR, static_cast<void*>(data));
+  parent->Dispatch(SetLocalDescriptionErrorEvent::Create(msg));
   TRACE_END;
 }

--- a/src/set-remote-description-observer.cc
+++ b/src/set-remote-description-observer.cc
@@ -15,13 +15,12 @@ using node_webrtc::SetRemoteDescriptionObserver;
 
 void SetRemoteDescriptionObserver::OnSuccess() {
   TRACE_CALL;
-  parent->QueueEvent(PeerConnection::SET_REMOTE_DESCRIPTION_SUCCESS, static_cast<void*>(nullptr));
+  parent->Dispatch(SetRemoteDescriptionSuccessEvent::Create());
   TRACE_END;
 }
 
 void SetRemoteDescriptionObserver::OnFailure(const std::string& msg) {
   TRACE_CALL;
-  PeerConnection::ErrorEvent* data = new PeerConnection::ErrorEvent(msg);
-  parent->QueueEvent(PeerConnection::SET_REMOTE_DESCRIPTION_ERROR, static_cast<void*>(data));
+  parent->Dispatch(SetRemoteDescriptionErrorEvent::Create(msg));
   TRACE_END;
 }

--- a/src/stats-observer.cc
+++ b/src/stats-observer.cc
@@ -29,7 +29,6 @@ void StatsObserver::OnComplete(const webrtc::StatsReports& statsReports) {
     }
     reports.push_back(report);
   }
-  PeerConnection::GetStatsEvent* data = new PeerConnection::GetStatsEvent(this->callback, timestamp, reports);
-  parent->QueueEvent(PeerConnection::GET_STATS_SUCCESS, static_cast<void*>(data));
+  parent->Dispatch(GetStatsEvent::Create(callback, timestamp, reports));
   TRACE_END;
 }


### PR DESCRIPTION
Here is another attempt at #364. IMO, it's easier to evaluate now, since other bugs have been fixed.

This should address the various memory leak issues, (#319, #304, and #205). The core issue is that we aren't deleting messages posted to the PeerConnection and DataChannel event loops. So, for example, if we receive a MessageEvent on a DataChannel, we never delete it, which means we leak the received buffer. Running @nazar-pc's script from #304 with these changes results in constant memory usage.

In order to solve this, I also took the opportunity to refactor our events into nicer, C++-style classes for processing via new classes, EventQueue and EventLoop. Using, e.g., `std::unique_ptr`s ensures we don't have to worry about manually `delete`-ing. Events are handled via double dispatch—basically, listing two from [Message Handling Without Dependencies](http://www.drdobbs.com/cpp/message-handling-without-dependencies/184429055). Per that article, there might be some opportunities to clean up boilerplate with this technique in the future.

- [x] Update DataChannel to use EventLoop
- [x] Update PeerConnection to use EventLoop