### PR TITLE
RTCRtpSender and MediaStream support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ list(REMOVE_ITEM MODULE_SRC_WITHOUT_WEBRTC
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(${MODULE} PRIVATE -DDEBUG)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
 target_include_directories(${MODULE} PRIVATE ${CMAKE_SOURCE_DIR})
@@ -74,7 +75,8 @@ if(APPLE)
     -DWEBRTC_POSIX=1)
 
   target_link_libraries(${MODULE} PRIVATE
-    "-framework AppKit")
+    "-framework AppKit"
+    "-framework AVFoundation")
 elseif(UNIX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
   target_compile_definitions(${MODULE} PRIVATE

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 var binding = require('./binding');
 
+exports.MediaStream = binding.MediaStream;
 exports.MediaStreamTrack = binding.MediaStreamTrack;
 exports.RTCDataChannel = require('./datachannel');
 exports.RTCDataChannelEvent = require('./datachannelevent');

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,4 +10,5 @@ exports.RTCIceCandidate = require('./icecandidate');
 exports.RTCPeerConnection = require('./peerconnection');
 exports.RTCPeerConnectionIceEvent = require('./rtcpeerconnectioniceevent');
 exports.RTCRtpReceiver = binding.RTCRtpReceiver;
+exports.RTCRtpSender = binding.RTCRtpSender;
 exports.RTCSessionDescription = require('./sessiondescription');

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -20,11 +20,12 @@ function RTCPeerConnection() {
   //
   // Attach events to the native PeerConnection object
   //
-  pc.ontrack = function ontrack(receiver) {
+  pc.ontrack = function ontrack(receiver, streams) {
     self.dispatchEvent({
       type: 'track',
       track: receiver.track,
-      receiver: receiver
+      receiver: receiver,
+      streams: streams
     });
   };
 

--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -182,6 +182,10 @@ RTCPeerConnection.prototype.addIceCandidate = function addIceCandidate(candidate
   return promise;
 };
 
+RTCPeerConnection.prototype.addTrack = function addTrack(track, stream) {
+  return this._pc.addTrack(track, stream);
+};
+
 RTCPeerConnection.prototype.close = function close() {
   this._pc.close();
 };
@@ -233,6 +237,10 @@ RTCPeerConnection.prototype.getReceivers = function getReceivers() {
   return this._pc.getReceivers();
 };
 
+RTCPeerConnection.prototype.getSenders = function getSenders() {
+  return this._pc.getSenders();
+};
+
 // NOTE(mroberts): simple-peer is doing feature detection based on the number of
 // arguments this method takes. Don't change this until we can support the
 // proper standards-based `getStats` API.
@@ -240,6 +248,10 @@ RTCPeerConnection.prototype.getStats = function getStats(onSuccess, onFailure) {
   this._pc.getStats().then(function(internalRTCStatsResponse) {
     return new RTCStatsResponse(internalRTCStatsResponse);
   }).then(onSuccess, onFailure);
+};
+
+RTCPeerConnection.prototype.removeTrack = function removeTrack(sender) {
+  this._pc.removeTrack(sender);
 };
 
 RTCPeerConnection.prototype.setConfiguration = function setConfiguration(configuration) {

--- a/src/bidimap.h
+++ b/src/bidimap.h
@@ -1,0 +1,202 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#ifndef SRC_BIDIMAP_H_
+#define SRC_BIDIMAP_H_
+
+#include <functional>
+#include <map>
+#include <utility>
+
+#include "src/functional/maybe.h"
+#include "src/functional/operators.h"
+
+namespace node_webrtc {
+
+/**
+ * A BidiMap is a "bidirectional map" supporting get and set operations on both
+ * keys and values.
+ * @tparam K the type of keys
+ * @tparam V the type of values
+ */
+template <typename K, typename V>
+class BidiMap {
+ public:
+  /**
+   * Construct an empty BidiMap.
+   */
+  BidiMap() = default;
+
+  /**
+   * Remove all keys and values from the BidiMap.
+   */
+  void clear() {
+    _keyToValue.clear();
+    _valueToKey.clear();
+  }
+
+  /**
+   * Compute, set, and return a key's value if it's absent; otherwise, return
+   * the key's value.
+   * @param key
+   * @param computeValue
+   * @return the existing or newly set value
+   */
+  V computeIfAbsent(K key, std::function<V()> computeValue) {
+    return get(key).Or([this, key, computeValue]() {
+      auto value = computeValue();
+      this->set(key, value);
+      return value;
+    });
+  }
+
+  /**
+   * Get the key's value from the BidiMap.
+   * @param key
+   * @return Nothing if the key was not present
+   */
+  Maybe<V> get(K key) const {
+    return has(key)
+        ? Maybe<V>::Just(_keyToValue.at(key))
+        : Maybe<V>::Nothing();
+  }
+
+  /**
+   * Check if the BidiMap contains a value for the key.
+   * @param key
+   * @return true if the BidiMap contains a value for the key
+   */
+  bool has(K key) const {
+    return _keyToValue.count(key) > 0;
+  }
+
+  /**
+   * Remove the key and its value from the BidiMap.
+   * @param key
+   * @return Nothing if the key was not present
+   */
+  Maybe<V> remove(K key) {
+    return [this, key](V value) {
+      this->_keyToValue.erase(key);
+      this->_valueToKey.erase(value);
+      return value;
+    } % get(key);
+  }
+
+  /**
+   * Return a BidiMap with its keys and values swapped.
+   * @return a BidiMap with its keys and values swapped
+   */
+  BidiMap<V, K> reverse() const {
+    return BidiMap<V, K>(_valueToKey, _keyToValue);
+  }
+
+  /**
+   * Compute, set, and return a value's key if it's absent; otherwise, return
+   * the value's key.
+   * @param value
+   * @param computeKey
+   * @return the existing or newly set key
+   */
+  K reverseComputeIfAbsent(V value, std::function<K()> computeKey) {
+    return reverseGet(value).Or([this, value, computeKey]() {
+      auto key = computeKey();
+      this->reverseSet(value, key);
+      return key;
+    });
+  }
+
+  /**
+   * Get the value's key from the BidiMap.
+   * @param value
+   * @return Nothing if the value was not present
+   */
+  Maybe<K> reverseGet(V value) const {
+    return reverseHas(value)
+        ? Maybe<K>::Just(_valueToKey.at(value))
+        : Maybe<K>::Nothing();
+  }
+
+  /**
+   * Check if the BidiMap contains a key for the value.
+   * @param value
+   * @return true if the BidiMap contains a key for the value
+   */
+  bool reverseHas(V value) const {
+    return _valueToKey.count(value) > 0;
+  }
+
+  /**
+   * Remove a value and its key from the BidiMap.
+   * @param value
+   * @return Nothing if the value was not present
+   */
+  Maybe<K> reverseRemove(V value) {
+    return [this, value](K key) {
+      this->_keyToValue.erase(key);
+      this->_valueToKey.erase(value);
+      return key;
+    } % reverseGet(value);
+  }
+
+  /**
+   * Set a value and its key in the BidiMap.
+   * @param value
+   * @param key
+   * @return a pair of the previously set key (if any) and the previously set
+   *         value (if any)
+   */
+  std::pair<Maybe<K>, Maybe<V>> reverseSet(V value, K key) {
+    auto pair = std::make_pair(reverseGet(value), get(key));
+    remove(key);
+    _valueToKey[value] = key;
+    _keyToValue[key] = value;
+    return pair;
+  }
+
+  /**
+   * Set a key and its value in the BidiMap.
+   * @param key
+   * @param value
+   * @return a pair of the previously set value (if any) and the previously set
+   *         key (if any)
+   */
+  std::pair<Maybe<V>, Maybe<K>> set(K key, V value) {
+    auto pair = std::make_pair(get(key), reverseGet(value));
+    reverseRemove(value);
+    _keyToValue[key] = value;
+    _valueToKey[value] = key;
+    return pair;
+  }
+
+  /**
+   * Construct a BidiMap from a map.
+   * @param map
+   * @return Nothing if the map contains duplicate values
+   */
+  static Maybe<BidiMap<K, V>> FromMap(std::map<K, V> map) {
+    BidiMap<K, V> bidiMap;
+    for (auto pair : map) {
+      auto previousKey = bidiMap.reverseSet(pair.second, pair.first);
+      if (previousKey.IsJust()) {
+        return Maybe<BidiMap<K, V>>::Nothing();
+      }
+    }
+    return Maybe<BidiMap<K, V>>::Just(bidiMap);
+  }
+
+ private:
+  BidiMap(const std::map<K, V>& keyToValue, const std::map<V, K>& valueToKey)
+    : _keyToValue(keyToValue), _valueToKey(valueToKey) {}
+
+  std::map<K, V> _keyToValue;
+  std::map<V, K> _valueToKey;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_BIDIMAP_H_

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -8,6 +8,7 @@
 #include "node.h"
 
 #include "datachannel.h"
+#include "mediastream.h"
 #include "mediastreamtrack.h"
 #include "rtcrtpreceiver.h"
 #include "rtcstatsreport.h"
@@ -26,6 +27,7 @@ void init(Handle<Object> exports) {
   node_webrtc::PeerConnectionFactory::Init(exports);
   node_webrtc::PeerConnection::Init(exports);
   node_webrtc::DataChannel::Init(exports);
+  node_webrtc::MediaStream::Init(exports);
   node_webrtc::MediaStreamTrack::Init(exports);
   node_webrtc::RTCRtpReceiver::Init(exports);
   node_webrtc::RTCStatsReport::Init(exports);

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -11,6 +11,7 @@
 #include "mediastream.h"
 #include "mediastreamtrack.h"
 #include "rtcrtpreceiver.h"
+#include "rtcrtpsender.h"
 #include "rtcstatsreport.h"
 #include "rtcstatsresponse.h"
 #include "peerconnection.h"
@@ -30,6 +31,7 @@ void init(Handle<Object> exports) {
   node_webrtc::MediaStream::Init(exports);
   node_webrtc::MediaStreamTrack::Init(exports);
   node_webrtc::RTCRtpReceiver::Init(exports);
+  node_webrtc::RTCRtpSender::Init(exports);
   node_webrtc::RTCStatsReport::Init(exports);
   node_webrtc::RTCStatsResponse::Init(exports);
   node::AtExit(dispose);

--- a/src/common.h
+++ b/src/common.h
@@ -45,41 +45,4 @@
 
 #endif
 
-#define THROW_TYPE_ERROR(MSG) \
-  return Nan::ThrowTypeError(MSG);
-
-#define CHECK_ARG(I, CHECK, DO_TRUE, DO_FALSE) \
-  if (info.Length() <= (I) || !info[I]->CHECK) { DO_FALSE; } else { DO_TRUE; }
-
-#define REQUIRE_ARG(I, CHECK) \
-  CHECK_ARG(I, CHECK, , THROW_TYPE_ERROR("Argument " #I " must be an object"))
-
-#define REQ_OBJ_ARG(I, VAR) \
-  REQUIRE_ARG(I, IsObject()) \
-  Local<Object> VAR = Local<Object>::Cast(info[I])
-
-#define OPT_INT_ARG(I, VAR, DEFAULT) \
-  int VAR; \
-  CHECK_ARG(I, IsNumber(), VAR = info[I]->Int32Value(), VAR = DEFAULT)
-
-#define REQ_INT_ARG(I, VAR) \
-  REQUIRE_ARG(I, IsNumber()) \
-  int VAR = info[I]->Int32Value();
-
-#define REQ_FUN_ARG(I, VAR)                                         \
-  if (info.Length() <= (I) || !info[I]->IsFunction())               \
-    return Nan::ThrowTypeError("Argument " #I " must be a function"); \
-  Local<Function> VAR = Local<Function>::Cast(info[I]);
-
-#define CREATE_BUFFER(name, data, length) \
-  Local<Object> name ## _buf = Nan::NewBuffer(length).ToLocalChecked(); \
-  memcpy(Buffer::Data(name ## _buf), data, length); \
-  Local<Object> name; \
-  Handle<Value> ctorArgs[3] = { name ## _buf, Nan::New<Integer>(length), Nan::New<Integer>(0) }; \
-  name = Local<Function>::Cast(\
-          Nan::GetCurrentContext() \
-          ->Global() \
-          ->Get(Nan::New("Buffer").ToLocalChecked()) \
-      )->NewInstance(3, ctorArgs);
-
 #endif  // SRC_COMMON_H_

--- a/src/converters/arguments.h
+++ b/src/converters/arguments.h
@@ -23,10 +23,23 @@
 
 namespace node_webrtc {
 
+struct Arguments {
+  Nan::NAN_METHOD_ARGS_TYPE info;
+  explicit Arguments(Nan::NAN_METHOD_ARGS_TYPE info): info(info) {}
+};
+
 template <typename A>
-struct Converter<Nan::NAN_METHOD_ARGS_TYPE, A> {
-  static Validation<A> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
-    return From<A>(info[0]);
+struct Converter<Arguments, A> {
+  static Validation<A> Convert(Arguments args) {
+    return From<A>(args.info[0]);
+  }
+};
+
+template <typename L, typename R>
+struct Converter<Arguments, Either<L, R>> {
+  static Validation<Either<L, R>> Convert(Arguments args) {
+    return From<L>(args).Map(&Either<L, R>::Left)
+        | (From<R>(args).Map(&Either<L, R>::Right));
   }
 };
 
@@ -36,11 +49,11 @@ static std::tuple<A, B> Make2Tuple(A a, B b) {
 }
 
 template <typename A, typename B>
-struct Converter<Nan::NAN_METHOD_ARGS_TYPE, std::tuple<A, B>> {
-  static Validation<std::tuple<A, B>> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
+struct Converter<Arguments, std::tuple<A, B>> {
+  static Validation<std::tuple<A, B>> Convert(Arguments args) {
     return curry(Make2Tuple<A, B>)
-        % From<A>(info[0])
-        * From<B>(info[1]);
+        % From<A>(args.info[0])
+        * From<B>(args.info[1]);
   }
 };
 
@@ -50,12 +63,12 @@ static std::tuple<A, B> Make3Tuple(A a, B b, C c) {
 }
 
 template <typename A, typename B, typename C>
-struct Converter<Nan::NAN_METHOD_ARGS_TYPE, std::tuple<A, B, C>> {
-  static Validation<std::tuple<A, B, C>> Convert(Nan::NAN_METHOD_ARGS_TYPE info) {
+struct Converter<Arguments, std::tuple<A, B, C>> {
+  static Validation<std::tuple<A, B, C>> Convert(Arguments args) {
     return curry(Make3Tuple<A, B, C>)
-        % From<A>(info[0])
-        * From<B>(info[1])
-        * From<C>(info[2]);
+        % From<A>(args.info[0])
+        * From<B>(args.info[1])
+        * From<C>(args.info[2]);
   }
 };
 

--- a/src/converters/v8.h
+++ b/src/converters/v8.h
@@ -45,6 +45,20 @@ struct Converter<SomeError, v8::Local<v8::Value>> {
   }
 };
 
+class Null {
+ public:
+  Null() {}
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, Null> {
+  static Validation<Null> Convert(const v8::Local<v8::Value> value) {
+    return value->IsNull()
+        ? Validation<Null>::Valid(Null())
+        : Validation<Null>::Invalid("Expected null");
+  }
+};
+
 class Undefined {
  public:
   Undefined() {}

--- a/src/converters/v8.h
+++ b/src/converters/v8.h
@@ -226,6 +226,16 @@ struct Converter<v8::Local<v8::Value>, v8::Local<v8::Object>> {
   }
 };
 
+template <>
+struct Converter<v8::Local<v8::Value>, v8::Local<v8::External>> {
+  static Validation<v8::Local<v8::External>> Convert(const v8::Local<v8::Value> value) {
+    Nan::EscapableHandleScope scope;
+    return !value.IsEmpty() && value->IsExternal()
+        ? Validation<v8::Local<v8::External>>::Valid(scope.Escape(v8::Local<v8::External>::Cast(value)))
+        : Validation<v8::Local<v8::External>>::Invalid("Expected an external");
+  }
+};
+
 }  // namespace node_webrtc
 
 #endif  // SRC_CONVERTERS_V8_H_

--- a/src/converters/webrtc.h
+++ b/src/converters/webrtc.h
@@ -25,6 +25,7 @@
 #include "src/mediastream.h"
 #include "src/mediastreamtrack.h"
 #include "src/rtcrtpreceiver.h"
+#include "src/rtcrtpsender.h"
 
 namespace node_webrtc {
 
@@ -639,7 +640,7 @@ template <>
 struct Converter<v8::Local<v8::Value>, node_webrtc::MediaStream*> {
   static Validation<node_webrtc::MediaStream*> Convert(v8::Local<v8::Value> value) {
     // TODO(mroberts): This is not safe.
-    return value->IsObject() && !value->IsArray()
+    return value->IsObject() && !value->IsNull() && !value->IsArray()
         ? Validation<node_webrtc::MediaStream*>::Valid(Nan::ObjectWrap::Unwrap<node_webrtc::MediaStream>(value->ToObject()))
         : Validation<node_webrtc::MediaStream*>::Invalid("IDK");
   }
@@ -660,9 +661,30 @@ template <>
 struct Converter<v8::Local<v8::Value>, node_webrtc::MediaStreamTrack*> {
   static Validation<node_webrtc::MediaStreamTrack*> Convert(v8::Local<v8::Value> value) {
     // TODO(mroberts): This is not safe.
-    return value->IsObject() && !value->IsArray()
+    return value->IsObject() && !value->IsNull() && !value->IsArray()
         ? Validation<node_webrtc::MediaStreamTrack*>::Valid(node_webrtc::AsyncObjectWrapWithLoop<node_webrtc::MediaStreamTrack>::Unwrap(value->ToObject()))
         : Validation<node_webrtc::MediaStreamTrack*>::Invalid("IDK");
+  }
+};
+
+template <>
+struct Converter<node_webrtc::RTCRtpSender*, v8::Local<v8::Value>> {
+  static Validation<v8::Local<v8::Value>> Convert(node_webrtc::RTCRtpSender* track) {
+    Nan::EscapableHandleScope scope;
+    if (!track) {
+      return Validation<v8::Local<v8::Value>>::Invalid("RTCRtpSender is null");
+    }
+    return Validation<v8::Local<v8::Value>>::Valid(scope.Escape(track->ToObject()));
+  }
+};
+
+template <>
+struct Converter<v8::Local<v8::Value>, node_webrtc::RTCRtpSender*> {
+  static Validation<node_webrtc::RTCRtpSender*> Convert(v8::Local<v8::Value> value) {
+    // TODO(mroberts): This is not safe.
+    return value->IsObject() && !value->IsNull() && !value->IsArray()
+        ? Validation<node_webrtc::RTCRtpSender*>::Valid(node_webrtc::AsyncObjectWrapWithLoop<node_webrtc::RTCRtpSender>::Unwrap(value->ToObject()))
+        : Validation<node_webrtc::RTCRtpSender*>::Invalid("IDK");
   }
 };
 

--- a/src/error.h
+++ b/src/error.h
@@ -27,7 +27,7 @@ template<typename T, typename U> struct argument_type<T(U)> { typedef U type; };
   auto NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::Validation<argument_type<void(T)>::type>::Invalid(std::vector<node_webrtc::Error>()); \
   { \
     Nan::TryCatch tc; \
-    NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::From<argument_type<void(T)>::type, Nan::NAN_METHOD_ARGS_TYPE>(info); \
+    NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::From<argument_type<void(T)>::type>(node_webrtc::Arguments(info)); \
     if (tc.HasCaught()) { \
       tc.ReThrow(); \
       return; \
@@ -59,7 +59,7 @@ template<typename T, typename U> struct argument_type<T(U)> { typedef U type; };
   auto NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::Validation<argument_type<void(T)>::type>::Invalid(std::vector<node_webrtc::Error>()); \
   { \
     Nan::TryCatch tc; \
-    NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::From<argument_type<void(T)>::type, Nan::NAN_METHOD_ARGS_TYPE>(info); \
+    NODE_WEBRTC_UNIQUE_NAME(validation) = node_webrtc::From<argument_type<void(T)>::type>(node_webrtc::Arguments(info)); \
     if (tc.HasCaught()) { \
       resolver->Resolve(tc.Exception()); \
       return; \

--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -66,10 +66,12 @@ class EventLoop: private EventQueue<T> {
   }
 
   virtual void Run() {
-    while (auto event = this->Dequeue()) {
-      event->Dispatch(_target);
-      if (_should_stop) {
-        break;
+    if (!_should_stop) {
+      while (auto event = this->Dequeue()) {
+        event->Dispatch(_target);
+        if (_should_stop) {
+          break;
+        }
       }
     }
     if (_should_stop) {

--- a/src/events.h
+++ b/src/events.h
@@ -252,15 +252,22 @@ class DataChannelEvent: public Event<PeerConnection> {
 class OnAddTrackEvent: public Event<PeerConnection> {
  public:
   rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver;
+  const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>> streams;
 
   void Dispatch(PeerConnection& peerConnection) override;
 
-  static std::unique_ptr<OnAddTrackEvent> Create(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) {
-    return std::unique_ptr<OnAddTrackEvent>(new OnAddTrackEvent(receiver));
+  static std::unique_ptr<OnAddTrackEvent> Create(
+      rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
+      const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>>& streams) {
+    return std::unique_ptr<OnAddTrackEvent>(new OnAddTrackEvent(receiver, streams));
   }
 
  private:
-  explicit OnAddTrackEvent(rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver): receiver(receiver) {}
+  explicit OnAddTrackEvent(
+      rtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver,
+      const std::vector<rtc::scoped_refptr<webrtc::MediaStreamInterface>>& streams)
+    : receiver(receiver)
+    , streams(streams) {}
 };
 
 }  // namespace node_webrtc

--- a/src/functional/maybe.h
+++ b/src/functional/maybe.h
@@ -15,6 +15,7 @@
 #define SRC_FUNCTIONAL_MAYBE_H_
 
 #include <cassert>
+#include <functional>
 #include <type_traits>
 
 namespace node_webrtc {
@@ -94,6 +95,16 @@ class Maybe {
    */
   Maybe<T> Or(const Maybe<T>& that) const {
     return _is_just ? this : that;
+  }
+
+  /**
+   * If "this" contains a value, return it; otherwise, compute a value and
+   * return it
+   * @param compute
+   * @return
+   */
+  T Or(std::function<T()> compute) const {
+    return _is_just ? _value : compute();
   }
 
   /**

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -221,7 +221,7 @@ NAN_METHOD(MediaStream::Clone) {
   CONVERT_OR_THROW_AND_RETURN(clonedMediaStreamTracks, tracks, Local<Value>);
   Local<Value> cargv[1];
   cargv[0] = tracks;
-  auto mediaStream = Nan::New(MediaStream::constructor)->NewInstance(1, cargv);
+  auto mediaStream = Nan::NewInstance(Nan::New(MediaStream::constructor), 1, cargv).ToLocalChecked();
   info.GetReturnValue().Set(mediaStream);
 }
 
@@ -233,8 +233,8 @@ MediaStream* MediaStream::GetOrCreate(
     Local<Value> cargv[2];
     cargv[0] = Nan::New<External>(static_cast<void*>(&factory));
     cargv[1] = Nan::New<External>(static_cast<void*>(&stream));
-    return Nan::ObjectWrap::Unwrap<MediaStream>(
-            Nan::New(MediaStream::constructor)->NewInstance(2, cargv));
+    auto mediaStream = Nan::NewInstance(Nan::New(MediaStream::constructor), 2, cargv).ToLocalChecked();
+    return Nan::ObjectWrap::Unwrap<MediaStream>(mediaStream);
   });
 }
 

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -189,9 +189,13 @@ NAN_METHOD(MediaStream::AddTrack) {
   auto stream = self->_stream;
   auto track = mediaStreamTrack->track();
   if (track->kind() == track->kAudioKind) {
-    stream->AddTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
+    if (stream->AddTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()))) {
+      mediaStreamTrack->AddRef();
+    }
   } else {
-    stream->AddTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
+    if (stream->AddTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()))) {
+      mediaStreamTrack->AddRef();
+    }
   }
 }
 
@@ -201,9 +205,13 @@ NAN_METHOD(MediaStream::RemoveTrack) {
   auto stream = self->_stream;
   auto track = mediaStreamTrack->track();
   if (track->kind() == track->kAudioKind) {
-    stream->RemoveTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
+    if (stream->RemoveTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()))) {
+      mediaStreamTrack->RemoveRef();
+    }
   } else {
-    stream->RemoveTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
+    if (stream->RemoveTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()))) {
+      mediaStreamTrack->RemoveRef();
+    }
   }
 }
 

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -1,0 +1,260 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "src/mediastream.h"
+
+#include "webrtc/base/helpers.h"
+
+#include "src/converters/arguments.h"
+#include "src/converters.h"
+#include "src/converters/v8.h"
+#include "src/converters/webrtc.h"
+
+using node_webrtc::BidiMap;
+using node_webrtc::Either;
+using node_webrtc::Maybe;
+using node_webrtc::MediaStream;
+using node_webrtc::MediaStreamTrack;
+using node_webrtc::PeerConnectionFactory;
+using v8::External;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+Nan::Persistent<Function> MediaStream::constructor;
+
+BidiMap<rtc::scoped_refptr<webrtc::MediaStreamInterface>, MediaStream*> MediaStream::_streams;
+
+MediaStream::MediaStream(std::shared_ptr<PeerConnectionFactory>&& factory)
+  : _factory(factory ? factory : PeerConnectionFactory::GetOrCreateDefault())
+  , _stream(_factory->factory()->CreateLocalMediaStream(rtc::CreateRandomUuid()))
+  , _shouldReleaseFactory(!factory) {
+}
+
+MediaStream::MediaStream(std::vector<MediaStreamTrack*>&& tracks, std::shared_ptr<PeerConnectionFactory>&& factory)
+  : _factory(factory ? factory : tracks.empty() ? PeerConnectionFactory::GetOrCreateDefault() : tracks[0]->factory())
+  , _stream(_factory->factory()->CreateLocalMediaStream(rtc::CreateRandomUuid()))
+  , _shouldReleaseFactory(!factory && tracks.empty()) {
+  for (auto const& track : tracks) {
+    track->AddRef();
+  }
+  for (auto const& track : tracks) {
+    if (track->track()->kind() == track->track()->kAudioKind) {
+      auto audioTrack = static_cast<webrtc::AudioTrackInterface*>(track->track().get());
+      _stream->AddTrack(audioTrack);
+    } else {
+      auto videoTrack = static_cast<webrtc::VideoTrackInterface*>(track->track().get());
+      _stream->AddTrack(videoTrack);
+    }
+  }
+}
+
+MediaStream::MediaStream(
+    rtc::scoped_refptr<webrtc::MediaStreamInterface>&& stream,
+    std::shared_ptr<PeerConnectionFactory>&& factory)
+  : _factory(factory ? factory : PeerConnectionFactory::GetOrCreateDefault())
+  , _stream(stream)
+  , _shouldReleaseFactory(!factory) {
+  for (auto const& track : tracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(_factory, track);
+    mediaStreamTrack->AddRef();
+  }
+}
+
+MediaStream::~MediaStream() {
+  for (auto const& track : tracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(_factory, track);
+    mediaStreamTrack->RemoveRef();
+  }
+  MediaStream::Release(this);
+  if (_shouldReleaseFactory) {
+    PeerConnectionFactory::Release();
+  }
+}
+
+NAN_METHOD(MediaStream::New) {
+  CONVERT_ARGS_OR_THROW_AND_RETURN(eithers, Either<std::tuple<Local<External> COMMA Local<External>> COMMA Either<std::vector<MediaStreamTrack*> COMMA Maybe<MediaStream*>>>);
+
+  MediaStream* mediaStream = nullptr;
+
+  if (eithers.IsLeft()) {
+    // 1. Remote MediaStream
+    auto pair = eithers.UnsafeFromLeft();
+    auto factory = *static_cast<std::shared_ptr<node_webrtc::PeerConnectionFactory>*>(Local<External>::Cast(std::get<0>(pair))->Value());
+    auto stream = *static_cast<rtc::scoped_refptr<webrtc::MediaStreamInterface>*>(Local<External>::Cast(std::get<1>(pair))->Value());
+    mediaStream = new MediaStream(std::move(stream), std::move(factory));
+  } else {
+    auto either = eithers.UnsafeFromRight();
+    if (either.IsLeft()) {
+      // 2. Local MediaStream, Array of MediaStreamTracks
+      auto tracks = either.UnsafeFromLeft();
+      mediaStream = new MediaStream(std::move(tracks));
+    } else {
+      auto maybeStream = either.UnsafeFromRight();
+      if (maybeStream.IsJust()) {
+        // 3. Local MediaStream, existing MediaStream
+        auto existingStream = maybeStream.UnsafeFromJust();
+        auto factory = existingStream->_factory;
+        auto tracks = std::vector<MediaStreamTrack*>();
+        for (auto const& track : existingStream->tracks()) {
+          tracks.push_back(MediaStreamTrack::GetOrCreate(factory, track));
+        }
+        mediaStream = new MediaStream(std::move(tracks), std::move(factory));
+      } else {
+        // 4. Local MediaStream
+        mediaStream = new MediaStream();
+      }
+    }
+  }
+
+  mediaStream->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
+}
+
+NAN_GETTER(MediaStream::GetId) {
+  (void) property;
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  info.GetReturnValue().Set(Nan::New(self->_stream->label()).ToLocalChecked());
+}
+
+NAN_GETTER(MediaStream::GetActive) {
+  (void) property;
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto active = false;
+  for (auto const& track : self->tracks()) {
+    active = active || track->state() == webrtc::MediaStreamTrackInterface::TrackState::kLive;
+  }
+  info.GetReturnValue().Set(Nan::New(active));
+}
+
+NAN_METHOD(MediaStream::GetAudioTracks) {
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto tracks = std::vector<MediaStreamTrack*>();
+  for (auto const& track : self->_stream->GetAudioTracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(self->_factory, track);
+    tracks.push_back(mediaStreamTrack);
+  }
+  CONVERT_OR_THROW_AND_RETURN(tracks, result, Local<Value>);
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(MediaStream::GetVideoTracks) {
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto tracks = std::vector<MediaStreamTrack*>();
+  for (auto const& track : self->_stream->GetVideoTracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(self->_factory, track);
+    tracks.push_back(mediaStreamTrack);
+  }
+  CONVERT_OR_THROW_AND_RETURN(tracks, result, Local<Value>);
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(MediaStream::GetTracks) {
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto tracks = std::vector<MediaStreamTrack*>();
+  for (auto const& track : self->tracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(self->_factory, track);
+    tracks.push_back(mediaStreamTrack);
+  }
+  CONVERT_OR_THROW_AND_RETURN(tracks, result, Local<Value>);
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(MediaStream::GetTrackById) {
+  CONVERT_ARGS_OR_THROW_AND_RETURN(label, std::string);
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto audioTrack = self->_stream->FindAudioTrack(label);
+  if (audioTrack) {
+    auto track = MediaStreamTrack::GetOrCreate(self->_factory, audioTrack);
+    info.GetReturnValue().Set(track->ToObject());
+  }
+  auto videoTrack = self->_stream->FindAudioTrack(label);
+  if (videoTrack) {
+    auto track = MediaStreamTrack::GetOrCreate(self->_factory, videoTrack);
+    info.GetReturnValue().Set(track->ToObject());
+  }
+}
+
+NAN_METHOD(MediaStream::AddTrack) {
+  CONVERT_ARGS_OR_THROW_AND_RETURN(mediaStreamTrack, MediaStreamTrack*);
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto stream = self->_stream;
+  auto track = mediaStreamTrack->track();
+  if (track->kind() == track->kAudioKind) {
+    stream->AddTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
+  } else {
+    stream->AddTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
+  }
+}
+
+NAN_METHOD(MediaStream::RemoveTrack) {
+  CONVERT_ARGS_OR_THROW_AND_RETURN(mediaStreamTrack, MediaStreamTrack*);
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto stream = self->_stream;
+  auto track = mediaStreamTrack->track();
+  if (track->kind() == track->kAudioKind) {
+    stream->RemoveTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
+  } else {
+    stream->RemoveTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
+  }
+}
+
+NAN_METHOD(MediaStream::Clone) {
+  (void) info;
+  auto self = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  auto clonedMediaStreamTracks = std::vector<Local<Value>>();
+  for (auto const& track : self->tracks()) {
+    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(self->_factory, track);
+    auto clonedMediaStreamTrack = Nan::Call("clone", mediaStreamTrack->ToObject(), 0, nullptr);
+    if (!clonedMediaStreamTrack.IsEmpty()) {
+      clonedMediaStreamTracks.push_back(clonedMediaStreamTrack.ToLocalChecked());
+    }
+  }
+  CONVERT_OR_THROW_AND_RETURN(clonedMediaStreamTracks, tracks, Local<Value>);
+  Local<Value> cargv[1];
+  cargv[0] = tracks;
+  auto mediaStream = Nan::New(MediaStream::constructor)->NewInstance(1, cargv);
+  info.GetReturnValue().Set(mediaStream);
+}
+
+MediaStream* MediaStream::GetOrCreate(
+    std::shared_ptr<PeerConnectionFactory> factory,
+    rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) {
+  return _streams.computeIfAbsent(stream, [&factory, &stream]() {
+    Nan::HandleScope scope;
+    Local<Value> cargv[2];
+    cargv[0] = Nan::New<External>(static_cast<void*>(&factory));
+    cargv[1] = Nan::New<External>(static_cast<void*>(&stream));
+    return Nan::ObjectWrap::Unwrap<MediaStream>(
+            Nan::New(MediaStream::constructor)->NewInstance(2, cargv));
+  });
+}
+
+void MediaStream::Release(MediaStream* stream) {
+  _streams.reverseRemove(stream);
+}
+
+void MediaStream::Init(Handle<Object> exports) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("MediaStream").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("id").ToLocalChecked(), GetId, nullptr);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("active").ToLocalChecked(), GetActive, nullptr);
+  Nan::SetPrototypeMethod(tpl, "getAudioTracks", GetAudioTracks);
+  Nan::SetPrototypeMethod(tpl, "getVideoTracks", GetVideoTracks);
+  Nan::SetPrototypeMethod(tpl, "getTracks", GetTracks);
+  Nan::SetPrototypeMethod(tpl, "getTrackById", GetTrackById);
+  Nan::SetPrototypeMethod(tpl, "addTrack", AddTrack);
+  Nan::SetPrototypeMethod(tpl, "removeTrack", RemoveTrack);
+  Nan::SetPrototypeMethod(tpl, "clone", Clone);
+  constructor.Reset(tpl->GetFunction());
+  exports->Set(Nan::New("MediaStream").ToLocalChecked(), tpl->GetFunction());
+}

--- a/src/mediastream.cc
+++ b/src/mediastream.cc
@@ -43,9 +43,6 @@ MediaStream::MediaStream(std::vector<MediaStreamTrack*>&& tracks, std::shared_pt
   , _stream(_factory->factory()->CreateLocalMediaStream(rtc::CreateRandomUuid()))
   , _shouldReleaseFactory(!factory && tracks.empty()) {
   for (auto const& track : tracks) {
-    track->AddRef();
-  }
-  for (auto const& track : tracks) {
     if (track->track()->kind() == track->track()->kAudioKind) {
       auto audioTrack = static_cast<webrtc::AudioTrackInterface*>(track->track().get());
       _stream->AddTrack(audioTrack);
@@ -62,17 +59,9 @@ MediaStream::MediaStream(
   : _factory(factory ? factory : PeerConnectionFactory::GetOrCreateDefault())
   , _stream(stream)
   , _shouldReleaseFactory(!factory) {
-  for (auto const& track : tracks()) {
-    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(_factory, track);
-    mediaStreamTrack->AddRef();
-  }
 }
 
 MediaStream::~MediaStream() {
-  for (auto const& track : tracks()) {
-    auto mediaStreamTrack = MediaStreamTrack::GetOrCreate(_factory, track);
-    mediaStreamTrack->RemoveRef();
-  }
   MediaStream::Release(this);
   if (_shouldReleaseFactory) {
     PeerConnectionFactory::Release();
@@ -189,13 +178,9 @@ NAN_METHOD(MediaStream::AddTrack) {
   auto stream = self->_stream;
   auto track = mediaStreamTrack->track();
   if (track->kind() == track->kAudioKind) {
-    if (stream->AddTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()))) {
-      mediaStreamTrack->AddRef();
-    }
+    stream->AddTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
   } else {
-    if (stream->AddTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()))) {
-      mediaStreamTrack->AddRef();
-    }
+    stream->AddTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
   }
 }
 
@@ -205,13 +190,9 @@ NAN_METHOD(MediaStream::RemoveTrack) {
   auto stream = self->_stream;
   auto track = mediaStreamTrack->track();
   if (track->kind() == track->kAudioKind) {
-    if (stream->RemoveTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()))) {
-      mediaStreamTrack->RemoveRef();
-    }
+    stream->RemoveTrack(static_cast<webrtc::AudioTrackInterface*>(track.get()));
   } else {
-    if (stream->RemoveTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()))) {
-      mediaStreamTrack->RemoveRef();
-    }
+    stream->RemoveTrack(static_cast<webrtc::VideoTrackInterface*>(track.get()));
   }
 }
 

--- a/src/mediastream.h
+++ b/src/mediastream.h
@@ -1,0 +1,78 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#ifndef SRC_MEDIASTREAM_H_
+#define SRC_MEDIASTREAM_H_
+
+#include "nan.h"
+#include "v8.h"
+
+#include "webrtc/api/mediastream.h"
+
+#include "src/bidimap.h"
+#include "src/mediastreamtrack.h"
+#include "src/peerconnectionfactory.h"
+
+namespace node_webrtc {
+
+class MediaStream
+  : public Nan::ObjectWrap {
+ public:
+  explicit MediaStream(std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory = nullptr);
+
+  explicit MediaStream(
+      std::vector<node_webrtc::MediaStreamTrack*>&& tracks,
+      std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory = nullptr);
+
+  explicit MediaStream(
+      rtc::scoped_refptr<webrtc::MediaStreamInterface>&& stream,
+      std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory = nullptr);
+
+  ~MediaStream() override;
+
+  static void Init(v8::Handle<v8::Object> exports);
+  static Nan::Persistent<v8::Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_GETTER(GetId);
+  static NAN_GETTER(GetActive);
+
+  static NAN_METHOD(GetAudioTracks);
+  static NAN_METHOD(GetVideoTracks);
+  static NAN_METHOD(GetTracks);
+  static NAN_METHOD(GetTrackById);
+  static NAN_METHOD(AddTrack);
+  static NAN_METHOD(RemoveTrack);
+  static NAN_METHOD(Clone);
+
+  static MediaStream* GetOrCreate(
+      std::shared_ptr<PeerConnectionFactory>,
+      rtc::scoped_refptr<webrtc::MediaStreamInterface>);
+  static void Release(MediaStream*);
+
+ private:
+  std::vector<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> tracks() {
+    auto tracks = std::vector<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>>();
+    for (auto const& track : _stream->GetAudioTracks()) {
+      tracks.emplace_back(track);
+    }
+    for (auto const& track : _stream->GetVideoTracks()) {
+      tracks.emplace_back(track);
+    }
+    return tracks;
+  }
+
+  const std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;
+  const rtc::scoped_refptr<webrtc::MediaStreamInterface> _stream;
+  const bool _shouldReleaseFactory;
+
+  static BidiMap<rtc::scoped_refptr<webrtc::MediaStreamInterface>, MediaStream*> _streams;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_MEDIASTREAM_H_

--- a/src/mediastream.h
+++ b/src/mediastream.h
@@ -54,6 +54,8 @@ class MediaStream
       rtc::scoped_refptr<webrtc::MediaStreamInterface>);
   static void Release(MediaStream*);
 
+  rtc::scoped_refptr<webrtc::MediaStreamInterface> stream() { return _stream; }
+
  private:
   std::vector<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>> tracks() {
     auto tracks = std::vector<rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>>();

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -117,8 +117,8 @@ MediaStreamTrack* MediaStreamTrack::GetOrCreate(
     Local<Value> cargv[2];
     cargv[0] = Nan::New<External>(static_cast<void*>(&factory));
     cargv[1] = Nan::New<External>(static_cast<void*>(&track));
-    return AsyncObjectWrapWithLoop<MediaStreamTrack>::Unwrap(
-            Nan::New(MediaStreamTrack::constructor)->NewInstance(2, cargv));
+    auto mediaStreamTrack = Nan::NewInstance(Nan::New(MediaStreamTrack::constructor), 2, cargv).ToLocalChecked();
+    return AsyncObjectWrapWithLoop<MediaStreamTrack>::Unwrap(mediaStreamTrack);
   });
 }
 

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -288,8 +288,8 @@ NAN_METHOD(PeerConnection::AddTrack) {
   Local<Value> cargv[2];
   cargv[0] = Nan::New<External>(static_cast<void*>(&self->_factory));
   cargv[1] = Nan::New<External>(static_cast<void*>(&rtpSender));
-  auto sender = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(
-          Nan::New(RTCRtpSender::constructor)->NewInstance(2, cargv));
+  auto obj = Nan::NewInstance(Nan::New(RTCRtpSender::constructor), 2, cargv).ToLocalChecked();
+  auto sender = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(obj);
   sender->AddRef();
   self->_senders.push_back(sender);
   TRACE_END;

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -28,6 +28,7 @@
 #include "events.h"
 #include "peerconnectionfactory.h"
 #include "rtcrtpreceiver.h"
+#include "rtcrtpsender.h"
 
 namespace node_webrtc {
 
@@ -69,6 +70,8 @@ class PeerConnection
   static Nan::Persistent<v8::Function> constructor;
   static NAN_METHOD(New);
 
+  static NAN_METHOD(AddTrack);
+  static NAN_METHOD(RemoveTrack);
   static NAN_METHOD(CreateOffer);
   static NAN_METHOD(CreateAnswer);
   static NAN_METHOD(SetLocalDescription);
@@ -86,6 +89,7 @@ class PeerConnection
   static NAN_METHOD(GetConfiguration);
   static NAN_METHOD(SetConfiguration);
   static NAN_METHOD(GetReceivers);
+  static NAN_METHOD(GetSenders);
   static NAN_METHOD(GetStats);
   static NAN_METHOD(Close);
 
@@ -123,6 +127,7 @@ class PeerConnection
   bool _shouldReleaseFactory;
 
   std::vector<node_webrtc::RTCRtpReceiver*> _receivers;
+  std::vector<node_webrtc::RTCRtpSender*> _senders;
 };
 
 }  // namespace node_webrtc

--- a/src/rtcrtpreceiver.cc
+++ b/src/rtcrtpreceiver.cc
@@ -44,14 +44,9 @@ NAN_METHOD(RTCRtpReceiver::New) {
 
   auto factory = *static_cast<std::shared_ptr<node_webrtc::PeerConnectionFactory>*>(Local<External>::Cast(info[0])->Value());
   auto receiver = *static_cast<rtc::scoped_refptr<webrtc::RtpReceiverInterface>*>(Local<External>::Cast(info[1])->Value());
-  auto track = receiver->track();
+  auto track = MediaStreamTrack::GetOrCreate(factory, receiver->track());
 
-  Local<Value> cargv[2];
-  cargv[0] = info[0];
-  cargv[1] = Nan::New<External>(static_cast<void*>(&track));
-  auto mediaStreamTrack = ::AsyncObjectWrap::Unwrap<MediaStreamTrack>(Nan::NewInstance(Nan::New(MediaStreamTrack::constructor), 2, cargv).ToLocalChecked());
-
-  auto obj = new RTCRtpReceiver(std::move(factory), std::move(receiver), mediaStreamTrack);
+  auto obj = new RTCRtpReceiver(std::move(factory), std::move(receiver), track);
   obj->Wrap(info.This());
 
   info.GetReturnValue().Set(info.This());

--- a/src/rtcrtpsender.cc
+++ b/src/rtcrtpsender.cc
@@ -1,0 +1,146 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "rtcrtpsender.h"
+
+#include "converters/v8.h"
+#include "converters/webrtc.h"
+#include "functional/maybe.h"
+#include "functional/operators.h"
+
+using node_webrtc::AsyncObjectWrapWithLoop;
+using node_webrtc::Maybe;
+using node_webrtc::MediaStreamTrack;
+using node_webrtc::RTCRtpSender;
+using v8::External;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::Local;
+using v8::Object;
+using v8::Value;
+
+Nan::Persistent<Function> RTCRtpSender::constructor;
+
+RTCRtpSender::RTCRtpSender(
+    std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
+    rtc::scoped_refptr<webrtc::RtpSenderInterface>&& sender,
+    node_webrtc::MediaStreamTrack* track)
+  : AsyncObjectWrapWithLoop("RTCRtpSender", *this)
+  , _factory(std::move(factory))
+  , _sender(std::move(sender))
+  , _track(track) {
+  if (_track) {
+    _track->AddRef();
+  }
+}
+
+RTCRtpSender::~RTCRtpSender() {
+  if (_track) {
+    _track->RemoveRef();
+  }
+}
+
+NAN_METHOD(RTCRtpSender::New) {
+  if (info.Length() != 2 || !info[0]->IsExternal() || !info[1]->IsExternal()) {
+    return Nan::ThrowTypeError("You cannot construct a RTCRtpSender");
+  }
+
+  auto factory = *static_cast<std::shared_ptr<node_webrtc::PeerConnectionFactory>*>(Local<External>::Cast(info[0])->Value());
+  auto sender = *static_cast<rtc::scoped_refptr<webrtc::RtpSenderInterface>*>(Local<External>::Cast(info[1])->Value());
+  auto track = MediaStreamTrack::GetOrCreate(factory, sender->track());
+
+  auto obj = new RTCRtpSender(std::move(factory), std::move(sender), track);
+  obj->Wrap(info.This());
+
+  info.GetReturnValue().Set(info.This());
+}
+
+NAN_GETTER(RTCRtpSender::GetTrack) {
+  (void) property;
+  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  Local<Value> result = Nan::Null();
+  if (self->_track) {
+    result = self->_track->ToObject();
+  }
+  info.GetReturnValue().Set(result);
+}
+
+NAN_GETTER(RTCRtpSender::GetTransport) {
+  (void) property;
+  info.GetReturnValue().Set(Nan::Null());
+}
+
+NAN_GETTER(RTCRtpSender::GetRtcpTransport) {
+  (void) property;
+  info.GetReturnValue().Set(Nan::Null());
+}
+
+NAN_METHOD(RTCRtpSender::GetCapabilities) {
+  (void) info;
+  Nan::ThrowError("Not yet implemented; file a feature request against node-webrtc");
+}
+
+NAN_METHOD(RTCRtpSender::GetParameters) {
+  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  auto parameters = self->_sender->GetParameters();
+  CONVERT_OR_THROW_AND_RETURN(parameters, result, Local<Value>);
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(RTCRtpSender::SetParameters) {
+  auto resolver = v8::Promise::Resolver::New(Nan::GetCurrentContext()->GetIsolate());
+  resolver->Reject(Nan::Error("Not yet implemented; file a feature request against node-webrtc"));
+  info.GetReturnValue().Set(resolver->GetPromise());
+}
+
+NAN_METHOD(RTCRtpSender::GetStats) {
+  auto resolver = v8::Promise::Resolver::New(Nan::GetCurrentContext()->GetIsolate());
+  resolver->Reject(Nan::Error("Not yet implemented; file a feature request against node-webrtc"));
+  info.GetReturnValue().Set(resolver->GetPromise());
+}
+
+NAN_METHOD(RTCRtpSender::ReplaceTrack) {
+  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  auto resolver = v8::Promise::Resolver::New(Nan::GetCurrentContext()->GetIsolate());
+  info.GetReturnValue().Set(resolver->GetPromise());
+  CONVERT_ARGS_OR_REJECT_AND_RETURN(resolver, maybeTrack, node_webrtc::Either<node_webrtc::Null COMMA MediaStreamTrack*>);
+  auto mediaStreamTrack = maybeTrack.FromEither<MediaStreamTrack*>([](Null) {
+    return nullptr;
+  }, [](MediaStreamTrack * track) {
+    return track;
+  });
+  auto track = mediaStreamTrack ? mediaStreamTrack->track().get() : nullptr;
+  if (self->_sender->SetTrack(track)) {
+    if (self->_track) {
+      self->_track->RemoveRef();
+    }
+    self->_track = mediaStreamTrack;
+    if (mediaStreamTrack) {
+      mediaStreamTrack->AddRef();
+    }
+    resolver->Resolve(Nan::Undefined());
+  } else {
+    resolver->Reject(Nan::Error("Failed to replaceTrack"));
+  }
+}
+
+void RTCRtpSender::Init(Handle<Object> exports) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("RTCRtpSender").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("track").ToLocalChecked(), GetTrack, nullptr);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("transport").ToLocalChecked(), GetTransport, nullptr);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("rtcpTransport").ToLocalChecked(), GetRtcpTransport, nullptr);
+  Nan::SetMethod(tpl, "getCapabilities", GetCapabilities);
+  Nan::SetPrototypeMethod(tpl, "getParameters", GetParameters);
+  Nan::SetPrototypeMethod(tpl, "setParameters", SetParameters);
+  Nan::SetPrototypeMethod(tpl, "getStats", GetStats);
+  Nan::SetPrototypeMethod(tpl, "replaceTrack", ReplaceTrack);
+  constructor.Reset(tpl->GetFunction());
+  exports->Set(Nan::New("RTCRtpSender").ToLocalChecked(), tpl->GetFunction());
+}

--- a/src/rtcrtpsender.cc
+++ b/src/rtcrtpsender.cc
@@ -12,7 +12,7 @@
 #include "functional/maybe.h"
 #include "functional/operators.h"
 
-using node_webrtc::AsyncObjectWrapWithLoop;
+using node_webrtc::AsyncObjectWrap;
 using node_webrtc::Maybe;
 using node_webrtc::MediaStreamTrack;
 using node_webrtc::RTCRtpSender;
@@ -30,7 +30,7 @@ RTCRtpSender::RTCRtpSender(
     std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
     rtc::scoped_refptr<webrtc::RtpSenderInterface>&& sender,
     node_webrtc::MediaStreamTrack* track)
-  : AsyncObjectWrapWithLoop("RTCRtpSender", *this)
+  : AsyncObjectWrap("RTCRtpSender")
   , _factory(std::move(factory))
   , _sender(std::move(sender))
   , _track(track) {
@@ -62,7 +62,7 @@ NAN_METHOD(RTCRtpSender::New) {
 
 NAN_GETTER(RTCRtpSender::GetTrack) {
   (void) property;
-  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  auto self = AsyncObjectWrap::Unwrap<RTCRtpSender>(info.Holder());
   Local<Value> result = Nan::Null();
   if (self->_track) {
     result = self->_track->ToObject();
@@ -86,7 +86,7 @@ NAN_METHOD(RTCRtpSender::GetCapabilities) {
 }
 
 NAN_METHOD(RTCRtpSender::GetParameters) {
-  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  auto self = AsyncObjectWrap::Unwrap<RTCRtpSender>(info.Holder());
   auto parameters = self->_sender->GetParameters();
   CONVERT_OR_THROW_AND_RETURN(parameters, result, Local<Value>);
   info.GetReturnValue().Set(result);
@@ -105,7 +105,7 @@ NAN_METHOD(RTCRtpSender::GetStats) {
 }
 
 NAN_METHOD(RTCRtpSender::ReplaceTrack) {
-  auto self = AsyncObjectWrapWithLoop<RTCRtpSender>::Unwrap(info.Holder());
+  auto self = AsyncObjectWrap::Unwrap<RTCRtpSender>(info.Holder());
   auto resolver = v8::Promise::Resolver::New(Nan::GetCurrentContext()->GetIsolate());
   info.GetReturnValue().Set(resolver->GetPromise());
   CONVERT_ARGS_OR_REJECT_AND_RETURN(resolver, maybeTrack, node_webrtc::Either<node_webrtc::Null COMMA MediaStreamTrack*>);

--- a/src/rtcrtpsender.h
+++ b/src/rtcrtpsender.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#ifndef SRC_RTCRTPSENDER_H_
+#define SRC_RTCRTPSENDER_H_
+
+#include "nan.h"
+#include "v8.h"
+
+#include "src/asyncobjectwrapwithloop.h"
+#include "src/peerconnectionfactory.h"
+#include "src/mediastreamtrack.h"
+
+namespace node_webrtc {
+
+class RTCRtpSender: public node_webrtc::AsyncObjectWrapWithLoop<RTCRtpSender> {
+ public:
+  RTCRtpSender(
+      std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
+      rtc::scoped_refptr<webrtc::RtpSenderInterface>&& sender,
+      node_webrtc::MediaStreamTrack* track);
+
+  ~RTCRtpSender() override;
+
+  static void Init(v8::Handle<v8::Object> exports);
+  static Nan::Persistent<v8::Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_GETTER(GetTrack);
+  static NAN_GETTER(GetTransport);
+  static NAN_GETTER(GetRtcpTransport);
+
+  static NAN_METHOD(GetCapabilities);
+
+  static NAN_METHOD(GetParameters);
+  static NAN_METHOD(SetParameters);
+  static NAN_METHOD(GetStats);
+  static NAN_METHOD(ReplaceTrack);
+
+  rtc::scoped_refptr<webrtc::RtpSenderInterface> sender() { return _sender; }
+
+ private:
+  const std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;
+  const rtc::scoped_refptr<webrtc::RtpSenderInterface> _sender;
+  node_webrtc::MediaStreamTrack* _track;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_RTCRTPSENDER_H_

--- a/src/rtcrtpsender.h
+++ b/src/rtcrtpsender.h
@@ -11,13 +11,13 @@
 #include "nan.h"
 #include "v8.h"
 
-#include "src/asyncobjectwrapwithloop.h"
+#include "src/asyncobjectwrap.h"
 #include "src/peerconnectionfactory.h"
 #include "src/mediastreamtrack.h"
 
 namespace node_webrtc {
 
-class RTCRtpSender: public node_webrtc::AsyncObjectWrapWithLoop<RTCRtpSender> {
+class RTCRtpSender: public node_webrtc::AsyncObjectWrap {
  public:
   RTCRtpSender(
       std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,

--- a/test/all.js
+++ b/test/all.js
@@ -7,6 +7,7 @@ require('./sessiondesc');
 require('./connect');
 require('./iceservers');
 // require('./bwtest').tape();
+require('./mediastream');
 require('./multiconnect');
 require('./custom-settings');
 require('./closing-peer-connection');

--- a/test/destructor/index.js
+++ b/test/destructor/index.js
@@ -2,7 +2,7 @@
 
 const test = require('tape');
 
-const { RTCPeerConnection, RTCSessionDescription } = require('../..');
+const { MediaStream, RTCPeerConnection, RTCSessionDescription } = require('../..');
 
 const checkDestructor = require('./util');
 
@@ -60,6 +60,22 @@ test('RTCPeerConnection\'s destructor fires', async t => {
       pc => pc.close());
     t.pass();
   });
+});
+
+test('RTCRtpSender\'s destructor fires', async t => {
+  t.plan(2);
+  await checkDestructor(
+    'RTCRtpSender',
+    async () => {
+      const pc = new RTCPeerConnection();
+      const offer = new RTCSessionDescription({ type: 'offer', sdp });
+      await pc.setRemoteDescription(offer);
+      pc.getReceivers().forEach(receiver => pc.addTrack(receiver.track, new MediaStream()));
+      t.equal(pc.getSenders().length, pc.getReceivers().length);
+      return pc;
+    },
+    pc => pc.close());
+  t.pass();
 });
 
 test('RTCDataChannel\'s destructor fires', async t => {

--- a/test/mediastream.js
+++ b/test/mediastream.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var tape = require('tape');
+var wrtc = require('..');
+
+var MediaStream = wrtc.MediaStream;
+var RTCPeerConnection = wrtc.RTCPeerConnection;
+var RTCSessionDescription = wrtc.RTCSessionDescription;
+
+var sdp = [
+  'v=0',
+  'o=- 0 1 IN IP4 0.0.0.0',
+  's=-',
+  't=0 0',
+  'a=group:BUNDLE audio video',
+  'a=msid-semantic:WMS *',
+  'a=ice-ufrag:0000',
+  'a=ice-pwd:0000000000000000000000',
+  'a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
+  'm=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101',
+  'c=IN IP4 0.0.0.0',
+  'a=mid:audio',
+  'a=sendrecv',
+  'a=rtpmap:109 opus/48000/2',
+  'a=rtpmap:9 G722/8000/1',
+  'a=rtpmap:0 PCMU/8000',
+  'a=rtpmap:8 PCMA/8000',
+  'a=rtpmap:101 PCMA/16000',
+  'a=rtcp-mux',
+  'a=ssrc:1 cname:0',
+  'a=ssrc:1 msid:stream 123',
+  'm=video 9 UDP/TLS/RTP/SAVPF 120 121 126 97',
+  'c=IN IP4 0.0.0.0',
+  'a=mid:video',
+  'a=sendrecv',
+  'a=rtpmap:120 VP8/90000',
+  'a=rtpmap:121 VP9/90000',
+  'a=rtpmap:126 H264/90000',
+  'a=rtpmap:97 H264/180000',
+  'a=rtcp-mux',
+  'a=ssrc:2 cname:0',
+  'a=ssrc:2 msid:stream 456'
+].join('\r\n') + '\r\n';
+
+tape('new MediaStream()', function(t) {
+  var stream = new MediaStream();
+  t.equal(stream.getTracks().length, 0, 'the MediaStream does not contain any MediaStreamTracks');
+  t.end();
+});
+
+tape('new MediaStream(stream)', function(t) {
+  return getMediaStream().then(function(stream1) {
+    var stream2 = new MediaStream(stream1);
+    t.notEqual(stream2.id, stream1.id, 'the MediaStream .ids do not match');
+    t.ok(stream2.getTracks().every(function(track, i) {
+      return track === stream1.getTracks()[i];
+    }) && stream1.getTracks().every(function(track, i) {
+      return track === stream2.getTracks()[i];
+    }), 'the MediaStreams\' MediaStreamTracks are the same');
+    t.end();
+  });
+});
+
+tape('new MediaStream(tracks)', function(t) {
+  return getMediaStream().then(function(stream1) {
+    var tracks = stream1.getTracks();
+    var stream2 = new MediaStream(tracks);
+    t.ok(stream2.getTracks().every(function(track, i) {
+      return track === tracks[i];
+    }) && tracks.every(function(track, i) {
+      return track === stream2.getTracks()[i];
+    }), 'the MediaStream\'s MediaStreamTracks match tracks');
+    t.end();
+  });
+});
+
+tape('.clone', function(t) {
+  return getMediaStream().then(function(stream1) {
+    var stream2 = stream1.clone();
+    var stream3 = stream2.clone();
+    // NOTE(mroberts): Weirdly, cloned video MediaStreamTracks have .readyState
+    // "live"; we'll .stop them, at least until that bug is fixed.
+    // stream2.getVideoTracks().forEach(function(track) {
+    stream2.getTracks().forEach(function(track) {
+      track.stop();
+    });
+    // stream3.getVideoTracks().forEach(function(track) {
+    stream3.getTracks().forEach(function(track) {
+      track.stop();
+    });
+    t.ok(
+      stream1.id !== stream2.id &&
+      stream2.id !== stream3.id &&
+      stream3.id !== stream1.id,
+      'the cloned MediaStreams have different IDs');
+    t.ok(
+      stream1.getTracks().length === stream2.getTracks().length &&
+      stream1.getTracks().length === stream3.getTracks().length,
+      'the cloned MediaStreams contain the same number of MediaStreamTracks');
+    t.ok(stream1.getTracks().every(function(track, i) {
+      return track.kind === stream2.getTracks()[i].kind &&
+        track.kind === stream3.getTracks()[i].kind;
+    }), 'the cloned MediaStreams contain the same kinds of MediaStreamTracks');
+    t.ok(stream1.getTracks().every(function(track, i) {
+      return track.id !== stream2.getTracks()[i].id &&
+        track.id !== stream3.getTracks()[i].id;
+    }), 'the cloned MediaStreams\'s MediaStreamTracks do not have the same .ids');
+    t.end();
+  });
+});
+
+tape('.removeTrack and .addTrack on remote MediaStream', function(t) {
+  return getMediaStream().then(function(stream) {
+    var tracks = stream.getTracks();
+    tracks.forEach(function(track) {
+      stream.removeTrack(track);
+    });
+    t.equal(stream.getTracks().length, 0, 'all MediaStreamTracks are removed');
+    tracks.forEach(function(track) {
+      stream.addTrack(track);
+    });
+    t.equal(stream.getTracks().length, tracks.length, 'all MediaStreamTracks are added back');
+    t.ok(stream.getTracks().every(function(track, i) {
+      return track === tracks[i];
+    }), 'all MediaStreamTracks added back are the same (and in the same order)');
+    t.end();
+  });
+});
+
+function getMediaStream() {
+  var pc = new RTCPeerConnection();
+  var offer = new RTCSessionDescription({ type: 'offer', sdp: sdp });
+  var trackEventPromise = new Promise(function(resolve) {
+    pc.ontrack = resolve;
+  });
+  return pc.setRemoteDescription(offer).then(function() {
+    return trackEventPromise;
+  }).then(function(trackEvent) {
+    pc.close();
+    return trackEvent.streams[0];
+  });
+}

--- a/test/rtcrtpsender.js
+++ b/test/rtcrtpsender.js
@@ -1,0 +1,106 @@
+'use strict';
+
+var tape = require('tape');
+var wrtc = require('..');
+
+var MediaStreamTrack = wrtc.MediaStreamTrack;
+var RTCPeerConnection = wrtc.RTCPeerConnection;
+var RTCRtpSender = wrtc.RTCRtpSender;
+var RTCSessionDescription = wrtc.RTCSessionDescription;
+
+var sdp = [
+  'v=0',
+  'o=- 0 1 IN IP4 0.0.0.0',
+  's=-',
+  't=0 0',
+  'a=group:BUNDLE audio video',
+  'a=msid-semantic:WMS *',
+  'a=ice-ufrag:0000',
+  'a=ice-pwd:0000000000000000000000',
+  'a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
+  'm=audio 9 UDP/TLS/RTP/SAVPF 109 9 0 8 101',
+  'c=IN IP4 0.0.0.0',
+  'a=mid:audio',
+  'a=sendrecv',
+  'a=rtpmap:109 opus/48000/2',
+  'a=rtpmap:9 G722/8000/1',
+  'a=rtpmap:0 PCMU/8000',
+  'a=rtpmap:8 PCMA/8000',
+  'a=rtpmap:101 PCMA/16000',
+  'a=rtcp-mux',
+  'a=ssrc:1 cname:0',
+  'a=ssrc:1 msid:stream 123',
+  'm=video 9 UDP/TLS/RTP/SAVPF 120 121 126 97',
+  'c=IN IP4 0.0.0.0',
+  'a=mid:video',
+  'a=sendrecv',
+  'a=rtpmap:120 VP8/90000',
+  'a=rtpmap:121 VP9/90000',
+  'a=rtpmap:126 H264/90000',
+  'a=rtpmap:97 H264/180000',
+  'a=rtcp-mux',
+  'a=ssrc:2 cname:0',
+  'a=ssrc:2 msid:stream 456'
+].join('\r\n') + '\r\n';
+
+tape('.addTrack(track, stream)', function(t) {
+  return getMediaStream().then(function(stream) {
+    var pc = new RTCPeerConnection();
+    t.equal(pc.getSenders().length, 0, 'initially, .getSenders() returns an empty Array');
+    var tracks = stream.getTracks();
+    var senders = tracks.map(function(track) {
+      return pc.addTrack(track, stream);
+    });
+    t.equal(pc.getSenders().length, senders.length, 'then, after calling .addTrack(track, stream), .getSenders() returns a non-empty Array');
+    t.ok(pc.getSenders().every(function(sender) {
+      return sender instanceof RTCRtpSender;
+    }), 'every element of the Array returned by .getSenders() is an RTCRtpSender');
+    t.ok(pc.getSenders().every(function(sender, i) {
+      return sender === senders[i];
+    }), 'every RTCRtpSender returned by .addTrack(track, stream) is present in .getSenders()');
+    t.ok(senders.every(function(sender, i) {
+      return sender.track === tracks[i];
+    }), 'every RTCRtpSender\'s .track is one of the MediaStreamTracks added');
+    senders.forEach(function(sender) {
+      pc.removeTrack(sender);
+    });
+    t.equal(pc.getSenders().length, 0, 'finally, after calling .removeTrack(sender), .getSenders() returns an empty Array again');
+    t.ok(senders.every(function(sender) {
+      return sender.track instanceof MediaStreamTrack;
+    }), 'but every RTCRtpSender\'s .track is still non-null');
+    pc.close();
+    t.end();
+  });
+});
+
+tape('.replaceTrack(null)', function(t) {
+  return getMediaStream().then(function(stream) {
+    var pc = new RTCPeerConnection();
+    var senders = stream.getTracks().map(function(track) {
+      return pc.addTrack(track, stream);
+    });
+    return Promise.all(senders.map(function(sender) {
+      return sender.replaceTrack(null);
+    })).then(function() {
+      t.ok(senders.every(function(sender) {
+        return sender.track === null;
+      }), 'every RTCRtpSender\'s .track is null');
+      pc.close();
+      t.end();
+    });
+  });
+});
+
+function getMediaStream() {
+  var pc = new RTCPeerConnection();
+  var offer = new RTCSessionDescription({ type: 'offer', sdp: sdp });
+  var trackEventPromise = new Promise(function(resolve) {
+    pc.ontrack = resolve;
+  });
+  return pc.setRemoteDescription(offer).then(function() {
+    return trackEventPromise;
+  }).then(function(trackEvent) {
+    pc.close();
+    return trackEvent.streams[0];
+  });
+}


### PR DESCRIPTION
_Not ready to merge._

See checklist in #396.

One thing to figure out how to do: raising `onaddtrack` and `onremovetrack` on the MediaStream. So far, objects that raise events extend from EventLoop; but these need to be stopped via Stop. There's no clear event that should trigger Stop, at least for both the local and remote MediaStreams. For remote MediaStreams this could coincide with closing the RTCPeerConnection; but I'm not sure about local MediaStreams. Perhaps MediaStream's private constructor could accept a boolean indicating whether it is local or not, and then we let local MediaStreams stop themselves immediately? That could solve the problem, although it feels a little weird. I think the alternative would require RTCPeerConnection driving events on remote MediaStreams it "owns" itself. The annoying thing, though, is that the observer for the MediaStream would get registered on the RTCPeerConnection rather than the MediaStream, and then the RTCPeerConnection would have to reach into the MediaStream to raise the events. Perhaps the former is cleaner then.