### PR TITLE
Prepare for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 New Features
 ------------
 
+- Added support for Node 10 (#402)
+
 ### RTCPeerConnection
 
 - Added support for `getReceivers`.

--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -59,10 +59,12 @@ class EventLoop: private EventQueue<T> {
   }
 
   virtual void Run() {
-    while (auto event = this->Dequeue()) {
-      event->Dispatch(_target);
-      if (_should_stop) {
-        break;
+    if (!_should_stop) {
+      while (auto event = this->Dequeue()) {
+        event->Dispatch(_target);
+        if (_should_stop) {
+          break;
+        }
       }
     }
     if (_should_stop) {

--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -59,12 +59,10 @@ class EventLoop: private EventQueue<T> {
   }
 
   virtual void Run() {
-    if (!_should_stop) {
-      while (auto event = this->Dequeue()) {
-        event->Dispatch(_target);
-        if (_should_stop) {
-          break;
-        }
+    while (auto event = this->Dequeue()) {
+      event->Dispatch(_target);
+      if (_should_stop) {
+        break;
       }
     }
     if (_should_stop) {

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -30,6 +30,10 @@ MediaStreamTrack::MediaStreamTrack(
   _track->RegisterObserver(this);
 }
 
+MediaStreamTrack::~MediaStreamTrack() {
+  _track->UnregisterObserver(this);
+}
+
 NAN_METHOD(MediaStreamTrack::New) {
   if (info.Length() != 2 || !info[0]->IsExternal() || !info[1]->IsExternal()) {
     return Nan::ThrowTypeError("You cannot construct a MediaStreamTrack");

--- a/src/mediastreamtrack.h
+++ b/src/mediastreamtrack.h
@@ -11,20 +11,23 @@
 #include "nan.h"
 #include "v8.h"
 
-#include "peerconnectionfactory.h"
-#include "promisefulfillingeventloop.h"
+#include "src/objectwrap.h"
+#include "src/peerconnectionfactory.h"
+#include "src/promisefulfillingeventloop.h"
 
 namespace node_webrtc {
 
 class MediaStreamTrack
   : public Nan::AsyncResource
-  , public Nan::ObjectWrap
+  , public node_webrtc::ObjectWrap
   , public node_webrtc::PromiseFulfillingEventLoop<MediaStreamTrack>
   , public webrtc::ObserverInterface {
  public:
   MediaStreamTrack(
       std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
       rtc::scoped_refptr<webrtc::MediaStreamTrackInterface>&& track);
+
+  ~MediaStreamTrack() override;
 
   static void Init(v8::Handle<v8::Object> exports);
   static Nan::Persistent<v8::Function> constructor;
@@ -37,6 +40,10 @@ class MediaStreamTrack
 
   // ObserverInterface
   void OnChanged() override;
+
+  void OnRTCRtpReceiverDestroyed() {
+    Stop();
+  }
 
  protected:
   void DidStop() override;

--- a/src/objectwrap.h
+++ b/src/objectwrap.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#ifndef SRC_OBJECTWRAP_H_
+#define SRC_OBJECTWRAP_H_
+
+#include "nan.h"
+
+namespace node_webrtc {
+
+class ObjectWrap: public Nan::ObjectWrap {
+ public:
+  void AddRef() {
+    Ref();
+  }
+
+  void RemoveRef() {
+    Unref();
+  }
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_OBJECTWRAP_H_

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -93,6 +93,9 @@ PeerConnection::PeerConnection(ExtendedRTCConfiguration configuration)
 PeerConnection::~PeerConnection() {
   TRACE_CALL;
   _jinglePeerConnection = nullptr;
+  for (auto receiver : _receivers) {
+    receiver->RemoveRef();
+  }
   _receivers.clear();
   if (_factory) {
     if (_shouldReleaseFactory) {
@@ -165,7 +168,7 @@ void PeerConnection::HandleOnAddTrackEvent(const OnAddTrackEvent& event) {
   auto receiver = Nan::ObjectWrap::Unwrap<RTCRtpReceiver>(
           Nan::NewInstance(Nan::New(RTCRtpReceiver::constructor), 2, cargv).ToLocalChecked()
       );
-
+  receiver->AddRef();
   _receivers.push_back(receiver);
 
   Local<Value> argv[1];

--- a/src/rtcrtpreceiver.cc
+++ b/src/rtcrtpreceiver.cc
@@ -27,7 +27,12 @@ RTCRtpReceiver::RTCRtpReceiver(
   : _factory(std::move(factory))
   , _receiver(std::move(receiver))
   , _track(track) {
-  // Do nothing.
+  _track->AddRef();
+}
+
+RTCRtpReceiver::~RTCRtpReceiver() {
+  _track->OnRTCRtpReceiverDestroyed();
+  _track->RemoveRef();
 }
 
 NAN_METHOD(RTCRtpReceiver::New) {
@@ -46,7 +51,6 @@ NAN_METHOD(RTCRtpReceiver::New) {
 
   auto obj = new RTCRtpReceiver(std::move(factory), std::move(receiver), mediaStreamTrack);
   obj->Wrap(info.This());
-  obj->Ref();
 
   info.GetReturnValue().Set(info.This());
 }

--- a/src/rtcrtpreceiver.h
+++ b/src/rtcrtpreceiver.h
@@ -10,18 +10,22 @@
 
 #include "nan.h"
 #include "v8.h"
-#include "peerconnectionfactory.h"
-#include "promisefulfillingeventloop.h"
-#include "mediastreamtrack.h"
+
+#include "src/mediastreamtrack.h"
+#include "src/objectwrap.h"
+#include "src/peerconnectionfactory.h"
+#include "src/promisefulfillingeventloop.h"
 
 namespace node_webrtc {
 
-class RTCRtpReceiver: public Nan::ObjectWrap {
+class RTCRtpReceiver: public node_webrtc::ObjectWrap {
  public:
   RTCRtpReceiver(
       std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
       rtc::scoped_refptr<webrtc::RtpReceiverInterface>&& receiver,
       node_webrtc::MediaStreamTrack* track);
+
+  ~RTCRtpReceiver() override;
 
   static void Init(v8::Handle<v8::Object> exports);
   static Nan::Persistent<v8::Function> constructor;
@@ -49,7 +53,7 @@ class RTCRtpReceiver: public Nan::ObjectWrap {
   bool _closed;
   const std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;
   const rtc::scoped_refptr<webrtc::RtpReceiverInterface> _receiver;
-  const std::shared_ptr<node_webrtc::MediaStreamTrack> _track;
+  node_webrtc::MediaStreamTrack* _track;
 };
 
 }  // namespace node_webrtc


### PR DESCRIPTION
I back-ported some memory fixes from #398 (`node_webrtc::ObjectWrap`, `AddRef`, `RemoveRef`). I did this because I wanted to confirm that we didn't leak memory with the new RTCRtpReceiver/MediaStreamTrack support. So I created a bunch of RTCPeerConnections and triggered RTCTrackEvents in a loop. Sure enough it exposed the issue (RTCRtpReceiver's MediaStreamTrack was getting freed early). Calling `AddRef` and `RemoveRef` and removing the `std::shared_ptr` fixed it.