### PR TITLE
Prepare for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 New Features
 ------------
 
+- This release allows relaying remote MediaStreamTracks. This can be useful for
+  test applications. **Note:** currently, Windows cannot relay audio
+  MediaStreamTracks, only video.
+
 ### MediaStream
 
 This release adds support for MediaStream. Most MediaStream APIs are supported,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,81 @@
+0.1.5
+=====
+
+New Features
+------------
+
+### MediaStream
+
+This release adds support for MediaStream. Most MediaStream APIs are supported,
+excluding the "addtrack" and "removetrack" events. You can construct
+MediaStreams as follows:
+
+```js
+const { MediaStream } = require('wrtc');
+
+const stream1 = new MediaStream();
+const stream2 = new MediaStream(stream1);
+```
+
+Assuming you already have some Array of MediaStreamTracks, `tracks`, you can
+also construct a MediaStream with
+
+```js
+const stream3 = new MediaStream(tracks);
+```
+
+Or, if you have an existing MediaStream, you can `clone` it.
+
+```js
+const stream4 = stream3.clone();
+```
+
+This release also adds support for the following methods
+
+- `getTracks`
+- `getAudioTracks`
+- `getVideoTracks`
+- `getTrackById`
+- `addTrack`
+- `removeTrack`
+
+and the following attributes
+
+- `id`
+- `active`
+
+### RTCTrackEvent
+
+This release adds support for the `streams` property.
+
+### RTCPeerConnection
+
+This release adds support for `addTrack`, `removeTrack`, and `getSenders`.
+Although we don't yet provide a way to construct local MediaStreamTracks, you
+can relay remote MediaStreamTracks as follows:
+
+```js
+pc.ontrack = ({ track, streams }) => {
+  pc.addTrack(track, ...streams);
+};
+```
+
+### RTCRtpSender
+
+This release adds support for the following methods
+
+- `getCapabilities` (always throws for now)
+- `getParameters`
+- `setParameters` (always returns a rejected Promise for now)
+- `getStats` (always returns a rejected Promise for now)
+- `replaceTrack`
+
+and the following attributes
+
+- `track`
+- `transport` (always returns `null` for now)
+- `rtcpTransport` (always returns `null` for now)
+
 0.1.4
 =====
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![NPM](https://img.shields.io/npm/v/wrtc.svg)](https://www.npmjs.com/package/wrtc) [![macOS/Linux Build Status](https://secure.travis-ci.org/js-platform/node-webrtc.svg?branch=develop)](http://travis-ci.org/js-platform/node-webrtc) [![Windows Build status](https://ci.appveyor.com/api/projects/status/iulc84we28o1i7b9?svg=true)](https://ci.appveyor.com/project/markandrus/node-webrtc-7bnua)
 
-node-webrtc provides Node.js bindings to [WebRTC M60](https://github.com/mayeut/libwebrtc/releases/tag/v1.1.1). You can write Node.js applications that use RTCDataChannels with it. **MediaStream APIs are not supported at this time.**
+node-webrtc provides Node.js bindings to [WebRTC M60](https://github.com/mayeut/libwebrtc/releases/tag/v1.1.1). You can write Node.js applications that use RTCDataChannels with it. **Some MediaStream APIs are supported now!.**
 
 |         | x86 | x64 | arm | arm64 |
 |:------- |:--- |:--- |:--- |:----- |

--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ npm test
 npm run wpt:test
 ```
 
+## MediaStream Loopback Example
+
+This example demonstrates relaying MediaStreamTracks through node-webrtc. Run
+the example with
+
+```
+node examples/loopback.server.js
+```
+
+Then navigate to [http://localhost:8080/loopback.client.html](http://localhost:8080/loopback.client.html).
+You should be prompted for your microphone and webcam. Once granted, the browser
+negotiates an RTCPeerConnection with the server, and the server relays the
+browser's MediaStreamTracks. Finally, these are displayed in a &lt;video&gt;
+element in the browser.
+
 # Contributing
 
 The best way to get started is to read through the `Getting Started` and `Example` sections before having a look through the open [issues](https://github.com/modeswitch/node-webrtc/issues). Some of the issues are marked as `good first bug`, but feel free to contribute to any of the issues there, or open a new one if the thing you want to work on isn't there yet.

--- a/examples/loopback.client.html
+++ b/examples/loopback.client.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<title>Loopback Client</title>
+</head>
+<body>
+<script src="/loopback.client.js"></script>
+</body>
+</html>

--- a/examples/loopback.client.js
+++ b/examples/loopback.client.js
@@ -1,0 +1,96 @@
+/* eslint no-cond-assign:0, no-console:0 */
+'use strict';
+
+const { RTCPeerConnection } = require('..');
+const { getAnswer, onCandidate } = require('./loopback.common');
+
+function onOpen(ws) {
+  return new Promise((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onclose = () => reject(new Error('WebSocket closed'));
+  });
+}
+
+async function main() {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: true,
+    video: true
+  });
+
+  console.log('Creating RTCPeerConnection');
+  const pc = new RTCPeerConnection({
+    bundlePolicy: 'max-bundle',
+    rtcpMuxPolicy: 'require'
+  });
+  stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+  function cleanup() {
+    console.log('Stopping MediaStreamTracks');
+    stream.getTracks().forEach(track => track.stop());
+    console.log('Closing RTCPeerConnection');
+    pc.close();
+  }
+
+  try {
+    const ws = new WebSocket('ws://localhost:8080');
+    await onOpen(ws);
+    ws.onclose = cleanup;
+
+    pc.onicecandidate = ({ candidate }) => {
+      if (candidate) {
+        console.log('Sending ICE candidate');
+        ws.send(JSON.stringify({
+          type: 'candidate',
+          candidate
+        }));
+      }
+    };
+
+    let queuedCandidates = [];
+    onCandidate(ws, async candidate => {
+      if (!pc.remoteDescription) {
+        queuedCandidates.push(candidate);
+        return;
+      }
+      console.log('Adding ICE candidate');
+      await pc.addIceCandidate(candidate);
+      console.log('Added ICE candidate');
+    });
+
+    const video = document.createElement('video');
+    document.body.appendChild(video);
+
+    pc.ontrack = ({ track, streams }) => {
+      console.log(`Received ${track.kind} MediaStreamTrack with ID ${track.id}`);
+      video.srcObject = streams[0];
+      video.autoplay = true;
+    };
+
+    console.log('Creating offer');
+    const offer = await pc.createOffer();
+
+    console.log('Created offer; setting local description');
+    await pc.setLocalDescription(offer);
+
+    console.log('Set local description; sending offer');
+    ws.send(JSON.stringify(offer));
+
+    console.log('Waiting for answer');
+    const answer = await getAnswer(ws);
+
+    console.log('Received answer; setting remote description');
+    await pc.setRemoteDescription(answer);
+    console.log('Set remote description');
+
+    await Promise.all(queuedCandidates.splice(0).map(async candidate => {
+      console.log('Adding ICE candidate');
+      await pc.addIceCandidate(candidate);
+      console.log('Added ICE candidate');
+    }));
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+}
+
+main();

--- a/examples/loopback.common.js
+++ b/examples/loopback.common.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const {
+  RTCIceCandidate,
+  RTCSessionDescription
+} = require('..');
+
+function getMessage(ws, type) {
+  return new Promise((resolve, reject) => {
+    function onMessage({ data }) {
+      try {
+        const message = JSON.parse(data);
+        if (message.type === type) {
+          resolve(message);
+        }
+      } catch (error) {
+        reject(error);
+      } finally {
+        cleanup();
+      }
+    }
+
+    function onClose() {
+      reject(new Error('WebSocket closed'));
+      cleanup();
+    }
+
+    function cleanup() {
+      ws.removeEventListener('message', onMessage);
+      ws.removeEventListener('close', onClose);
+    }
+
+    ws.addEventListener('message', onMessage);
+    ws.addEventListener('close', onClose);
+  });
+}
+
+async function getOffer(ws) {
+  const offer = await getMessage(ws, 'offer');
+  return new RTCSessionDescription(offer);
+}
+
+async function getAnswer(ws) {
+  const answer = await getMessage(ws, 'answer');
+  return new RTCSessionDescription(answer);
+}
+
+function onCandidate(ws, callback) {
+  ws.addEventListener('message', ({ data }) => {
+    try {
+      const message = JSON.parse(data);
+      if (message.type === 'candidate') {
+        const candidate = new RTCIceCandidate(message.candidate);
+        callback(candidate);
+        return;
+      }
+    } catch (error) {
+      // Do nothing.
+    }
+  });
+}
+
+exports.getOffer = getOffer;
+exports.getAnswer = getAnswer;
+exports.onCandidate = onCandidate;

--- a/examples/loopback.server.js
+++ b/examples/loopback.server.js
@@ -1,0 +1,94 @@
+/* eslint no-cond-assign:0, no-console:0 */
+'use strict';
+
+const express = require('express');
+const expressBrowserify = require('express-browserify');
+const { createServer } = require('http');
+const { join } = require('path');
+const { Server } = require('ws');
+
+const { RTCPeerConnection } = require('..');
+const { getOffer, onCandidate } = require('./loopback.common');
+
+const app = express();
+
+app.get('/loopback.client.js', expressBrowserify(join(__dirname, 'loopback.client.js')));
+
+app.use(express.static(__dirname));
+
+const server = createServer(app);
+
+server.listen(8080, () => {
+  const address = server.address();
+  console.log(`Server running at ${address.port}`);
+});
+
+let i = 0;
+
+new Server({ server }).on('connection', async ws => {
+  const n = i++;
+
+  console.log(`${n}: Creating new RTCPeerConnection`);
+
+  const pc = new RTCPeerConnection({
+    bundlePolicy: 'max-bundle',
+    rtcpMuxPolicy: 'require'
+  });
+
+  pc.onicecandidate = ({ candidate }) => {
+    if (candidate) {
+      console.log(`${n}: Sending ICE candidate`);
+      ws.send(JSON.stringify({
+        type: 'candidate',
+        candidate
+      }));
+    }
+  };
+
+  pc.ontrack = ({ track, streams }) => {
+    console.log(`${n}: Received ${track.kind} MediaStreamTrack with ID ${track.id}`);
+    pc.addTrack(track, ...streams);
+  };
+
+  let queuedCandidates = [];
+  onCandidate(ws, async candidate => {
+    if (!pc.remoteDescription) {
+      queuedCandidates.push(candidate);
+      return;
+    }
+    console.log(`${n}: Adding ICE candidate`);
+    await pc.addIceCandidate(candidate);
+    console.log(`${n}: Added ICE candidate`);
+  });
+
+  ws.once('close', () => {
+    console.log(`${n}: Closing RTCPeerConnection`);
+    pc.close();
+  });
+
+  try {
+    console.log(`${n}: Waiting for offer`);
+    const offer = await getOffer(ws);
+
+    console.log(`${n}: Received offer; setting remote description`);
+    await pc.setRemoteDescription(offer);
+
+    console.log(`${n}: Set remote description; creating answer`);
+    const answer = await pc.createAnswer();
+
+    console.log(`${n}: Created answer; setting local description`);
+    await pc.setLocalDescription(answer);
+
+    console.log(`${n}: Set local description; sending answer`);
+    ws.send(JSON.stringify(answer));
+
+    await Promise.all(queuedCandidates.splice(0).map(async candidate => {
+      console.log(`${n}: Adding ICE candidate`);
+      await pc.addIceCandidate(candidate);
+      console.log(`${n}: Added ICE candidate`);
+    }));
+  } catch (error) {
+    console.error(error.stack || error.message || error);
+    ws.close();
+  }
+});

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,6 @@
 'use strict';
 
+exports.MediaStream = window.MediaStream;
 exports.RTCIceCandidate = window.RTCIceCandidate;
 exports.RTCPeerConnection = window.RTCPeerConnection;
 exports.RTCSessionDescription = window.RTCSessionDescription;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tap-spec": "^4.1.1",
     "tape": "^2.4.3",
     "travis-multirunner": "^4.3.0",
-    "ws": "^1.1.0"
+    "ws": "^5.2.0"
   },
   "scripts": {
     "install": "node scripts/install.js",

--- a/src/peerconnectionfactory.h
+++ b/src/peerconnectionfactory.h
@@ -16,6 +16,7 @@
 #include "webrtc/modules/audio_device/include/audio_device.h"
 #include "webrtc/pc/peerconnectionfactory.h"
 
+#include "src/functional/maybe.h"
 #include "src/webrtc/physicalsocketserver.h"
 
 namespace node_webrtc {
@@ -26,7 +27,8 @@ class PeerConnectionFactory
   /**
    * Create a PeerConnectionFactory using a particular webrtc::AudioDeviceModule::AudioLayer.
    */
-  explicit PeerConnectionFactory(webrtc::AudioDeviceModule::AudioLayer audioLayer = webrtc::AudioDeviceModule::kDummyAudio);
+  explicit PeerConnectionFactory(
+      Maybe<webrtc::AudioDeviceModule::AudioLayer> audioLayer = Maybe<webrtc::AudioDeviceModule::AudioLayer>::Nothing());
 
   ~PeerConnectionFactory() override;
 

--- a/src/webrtc/fake_audio_device.cc
+++ b/src/webrtc/fake_audio_device.cc
@@ -1,0 +1,377 @@
+/*
+ *  Copyright (c) 2013 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "src/webrtc/fake_audio_device.h"
+
+#include <algorithm>
+#include <utility>
+
+#include "webrtc/base/checks.h"
+#include "webrtc/base/random.h"
+#include "webrtc/common_audio/wav_file.h"
+#include "webrtc/system_wrappers/include/event_wrapper.h"
+
+namespace node_webrtc {
+
+namespace {
+
+constexpr int kFrameLengthMs = 10;
+constexpr int kFramesPerSecond = 1000 / kFrameLengthMs;
+
+// Assuming 10ms audio packets..
+class PulsedNoiseCapturer final : public node_webrtc::FakeAudioDevice::Capturer {
+ public:
+  PulsedNoiseCapturer(int16_t max_amplitude, int sampling_frequency_in_hz)
+    : sampling_frequency_in_hz_(sampling_frequency_in_hz),
+      fill_with_zero_(false),
+      random_generator_(1),
+      max_amplitude_(max_amplitude) {
+    RTC_DCHECK_GT(max_amplitude, 0);
+  }
+
+  int SamplingFrequency() const override {
+    return sampling_frequency_in_hz_;
+  }
+
+  bool Capture(rtc::BufferT<int16_t>* buffer) override {
+    fill_with_zero_ = !fill_with_zero_;
+    buffer->SetData(
+        node_webrtc::FakeAudioDevice::SamplesPerFrame(sampling_frequency_in_hz_),
+    [&](rtc::ArrayView<int16_t> data) {
+      if (fill_with_zero_) {
+        std::fill(data.begin(), data.end(), 0);
+      } else {
+        std::generate(data.begin(), data.end(), [&]() {
+          return random_generator_.Rand(-max_amplitude_, max_amplitude_);
+        });
+      }
+      return data.size();
+    });
+    return true;
+  }
+
+ private:
+  int sampling_frequency_in_hz_;
+  bool fill_with_zero_;
+  webrtc::Random random_generator_;
+  const int16_t max_amplitude_;
+};
+
+class WavFileReader final : public node_webrtc::FakeAudioDevice::Capturer {
+ public:
+  WavFileReader(std::string filename, int sampling_frequency_in_hz)
+    : sampling_frequency_in_hz_(sampling_frequency_in_hz),
+      wav_reader_(filename) {
+    RTC_CHECK_EQ(wav_reader_.sample_rate(), sampling_frequency_in_hz);
+    RTC_CHECK_EQ(wav_reader_.num_channels(), 1);
+  }
+
+  int SamplingFrequency() const override {
+    return sampling_frequency_in_hz_;
+  }
+
+  bool Capture(rtc::BufferT<int16_t>* buffer) override {
+    buffer->SetData(
+        node_webrtc::FakeAudioDevice::SamplesPerFrame(sampling_frequency_in_hz_),
+    [&](rtc::ArrayView<int16_t> data) {
+      return wav_reader_.ReadSamples(data.size(), data.data());
+    });
+    return buffer->size() > 0;
+  }
+
+ private:
+  int sampling_frequency_in_hz_;
+  webrtc::WavReader wav_reader_;
+};
+
+class WavFileWriter final : public node_webrtc::FakeAudioDevice::Renderer {
+ public:
+  WavFileWriter(std::string filename, int sampling_frequency_in_hz)
+    : sampling_frequency_in_hz_(sampling_frequency_in_hz),
+      wav_writer_(filename, sampling_frequency_in_hz, 1) {}
+
+  int SamplingFrequency() const override {
+    return sampling_frequency_in_hz_;
+  }
+
+  bool Render(rtc::ArrayView<const int16_t> data) override {
+    wav_writer_.WriteSamples(data.data(), data.size());
+    return true;
+  }
+
+ private:
+  int sampling_frequency_in_hz_;
+  webrtc::WavWriter wav_writer_;
+};
+
+class BoundedWavFileWriter : public node_webrtc::FakeAudioDevice::Renderer {
+ public:
+  BoundedWavFileWriter(std::string filename, int sampling_frequency_in_hz)
+    : sampling_frequency_in_hz_(sampling_frequency_in_hz),
+      wav_writer_(filename, sampling_frequency_in_hz, 1),
+      silent_audio_(node_webrtc::FakeAudioDevice::SamplesPerFrame(
+              sampling_frequency_in_hz), 0),
+      started_writing_(false),
+      trailing_zeros_(0) {}
+
+  int SamplingFrequency() const override {
+    return sampling_frequency_in_hz_;
+  }
+
+  bool Render(rtc::ArrayView<const int16_t> data) override {
+    const int16_t kAmplitudeThreshold = 5;
+
+    const int16_t* begin = data.begin();
+    const int16_t* end = data.end();
+    if (!started_writing_) {
+      // Cut off silence at the beginning.
+      while (begin < end) {
+        if (std::abs(*begin) > kAmplitudeThreshold) {
+          started_writing_ = true;
+          break;
+        }
+        ++begin;
+      }
+    }
+    if (started_writing_) {
+      // Cut off silence at the end.
+      while (begin < end) {
+        if (*(end - 1) != 0) {
+          break;
+        }
+        --end;
+      }
+      if (begin < end) {
+        // If it turns out that the silence was not final, need to write all the
+        // skipped zeros and continue writing audio.
+        while (trailing_zeros_ > 0) {
+          const size_t zeros_to_write = std::min(trailing_zeros_,
+                  silent_audio_.size());
+          wav_writer_.WriteSamples(silent_audio_.data(), zeros_to_write);
+          trailing_zeros_ -= zeros_to_write;
+        }
+        wav_writer_.WriteSamples(begin, end - begin);
+      }
+      // Save the number of zeros we skipped in case this needs to be restored.
+      trailing_zeros_ += data.end() - end;
+    }
+    return true;
+  }
+
+ private:
+  int sampling_frequency_in_hz_;
+  webrtc::WavWriter wav_writer_;
+  std::vector<int16_t> silent_audio_;
+  bool started_writing_;
+  size_t trailing_zeros_;
+};
+
+
+class DiscardRenderer final : public node_webrtc::FakeAudioDevice::Renderer {
+ public:
+  explicit DiscardRenderer(int sampling_frequency_in_hz)
+    : sampling_frequency_in_hz_(sampling_frequency_in_hz) {}
+
+  int SamplingFrequency() const override {
+    return sampling_frequency_in_hz_;
+  }
+
+  bool Render(rtc::ArrayView<const int16_t>) override {
+    return true;
+  }
+
+ private:
+  int sampling_frequency_in_hz_;
+};
+
+}  // namespace
+
+size_t FakeAudioDevice::SamplesPerFrame(int sampling_frequency_in_hz) {
+  return rtc::CheckedDivExact(sampling_frequency_in_hz, kFramesPerSecond);
+}
+
+std::unique_ptr<FakeAudioDevice::Capturer>
+FakeAudioDevice::CreatePulsedNoiseCapturer(
+    int16_t max_amplitude, int sampling_frequency_in_hz) {
+  return std::unique_ptr<FakeAudioDevice::Capturer>(
+          new PulsedNoiseCapturer(max_amplitude, sampling_frequency_in_hz));
+}
+
+std::unique_ptr<FakeAudioDevice::Capturer> FakeAudioDevice::CreateWavFileReader(
+    std::string filename, int sampling_frequency_in_hz) {
+  return std::unique_ptr<FakeAudioDevice::Capturer>(
+          new WavFileReader(filename, sampling_frequency_in_hz));
+}
+
+std::unique_ptr<FakeAudioDevice::Capturer> FakeAudioDevice::CreateWavFileReader(
+    std::string filename) {
+  int sampling_frequency_in_hz = webrtc::WavReader(filename).sample_rate();
+  return std::unique_ptr<FakeAudioDevice::Capturer>(
+          new WavFileReader(filename, sampling_frequency_in_hz));
+}
+
+std::unique_ptr<FakeAudioDevice::Renderer> FakeAudioDevice::CreateWavFileWriter(
+    std::string filename, int sampling_frequency_in_hz) {
+  return std::unique_ptr<FakeAudioDevice::Renderer>(
+          new WavFileWriter(filename, sampling_frequency_in_hz));
+}
+
+std::unique_ptr<FakeAudioDevice::Renderer>
+FakeAudioDevice::CreateBoundedWavFileWriter(
+    std::string filename, int sampling_frequency_in_hz) {
+  return std::unique_ptr<FakeAudioDevice::Renderer>(
+          new BoundedWavFileWriter(filename, sampling_frequency_in_hz));
+}
+
+std::unique_ptr<FakeAudioDevice::Renderer>
+FakeAudioDevice::CreateDiscardRenderer(int sampling_frequency_in_hz) {
+  return std::unique_ptr<FakeAudioDevice::Renderer>(
+          new DiscardRenderer(sampling_frequency_in_hz));
+}
+
+
+FakeAudioDevice::FakeAudioDevice(std::unique_ptr<Capturer> capturer,
+    std::unique_ptr<Renderer> renderer,
+    float speed)
+  : capturer_(std::move(capturer)),
+    renderer_(std::move(renderer)),
+    speed_(speed),
+    audio_callback_(nullptr),
+    rendering_(false),
+    capturing_(false),
+    done_rendering_(true, true),
+    done_capturing_(true, true),
+    tick_(webrtc::EventTimerWrapper::Create()),
+    thread_(FakeAudioDevice::Run, this, "FakeAudioDevice") {
+  auto good_sample_rate = [](int sr) {
+    return sr == 8000 || sr == 16000 || sr == 32000
+        || sr == 44100 || sr == 48000;
+  };
+
+  if (renderer_) {
+    const int sample_rate = renderer_->SamplingFrequency();
+    playout_buffer_.resize(SamplesPerFrame(sample_rate), 0);
+    RTC_CHECK(good_sample_rate(sample_rate));
+  }
+  if (capturer_) {
+    RTC_CHECK(good_sample_rate(capturer_->SamplingFrequency()));
+  }
+}
+
+FakeAudioDevice::~FakeAudioDevice() {
+  StopPlayout();
+  StopRecording();
+  thread_.Stop();
+}
+
+int32_t FakeAudioDevice::StartPlayout() {
+  rtc::CritScope cs(&lock_);
+  RTC_CHECK(renderer_);
+  rendering_ = true;
+  done_rendering_.Reset();
+  return 0;
+}
+
+int32_t FakeAudioDevice::StopPlayout() {
+  rtc::CritScope cs(&lock_);
+  rendering_ = false;
+  done_rendering_.Set();
+  return 0;
+}
+
+int32_t FakeAudioDevice::StartRecording() {
+  rtc::CritScope cs(&lock_);
+  RTC_CHECK(capturer_);
+  capturing_ = true;
+  done_capturing_.Reset();
+  return 0;
+}
+
+int32_t FakeAudioDevice::StopRecording() {
+  rtc::CritScope cs(&lock_);
+  capturing_ = false;
+  done_capturing_.Set();
+  return 0;
+}
+
+int32_t FakeAudioDevice::Init() {
+  RTC_CHECK(tick_->StartTimer(true, kFrameLengthMs / speed_));
+  thread_.Start();
+  thread_.SetPriority(rtc::kHighPriority);
+  return 0;
+}
+
+int32_t FakeAudioDevice::RegisterAudioCallback(webrtc::AudioTransport* callback) {
+  rtc::CritScope cs(&lock_);
+  RTC_DCHECK(callback || audio_callback_);
+  audio_callback_ = callback;
+  return 0;
+}
+
+bool FakeAudioDevice::Playing() const {
+  rtc::CritScope cs(&lock_);
+  return rendering_;
+}
+
+bool FakeAudioDevice::Recording() const {
+  rtc::CritScope cs(&lock_);
+  return capturing_;
+}
+
+bool FakeAudioDevice::WaitForPlayoutEnd(int timeout_ms) {
+  return done_rendering_.Wait(timeout_ms);
+}
+
+bool FakeAudioDevice::WaitForRecordingEnd(int timeout_ms) {
+  return done_capturing_.Wait(timeout_ms);
+}
+
+bool FakeAudioDevice::Run(void* obj) {
+  static_cast<FakeAudioDevice*>(obj)->ProcessAudio();
+  return true;
+}
+
+void FakeAudioDevice::ProcessAudio() {
+  {
+    rtc::CritScope cs(&lock_);
+    if (capturing_) {
+      // Capture 10ms of audio. 2 bytes per sample.
+      const bool keep_capturing = capturer_->Capture(&recording_buffer_);
+      uint32_t new_mic_level;
+      if (recording_buffer_.size() > 0) {
+        audio_callback_->RecordedDataIsAvailable(
+            recording_buffer_.data(), recording_buffer_.size(), 2, 1,
+            capturer_->SamplingFrequency(), 0, 0, 0, false, new_mic_level);
+      }
+      if (!keep_capturing) {
+        capturing_ = false;
+        done_capturing_.Set();
+      }
+    }
+    if (rendering_) {
+      size_t samples_out;
+      int64_t elapsed_time_ms;
+      int64_t ntp_time_ms;
+      const int sampling_frequency = renderer_->SamplingFrequency();
+      audio_callback_->NeedMorePlayData(
+          SamplesPerFrame(sampling_frequency), 2, 1, sampling_frequency,
+          playout_buffer_.data(), samples_out, &elapsed_time_ms, &ntp_time_ms);
+      const bool keep_rendering = renderer_->Render(
+              rtc::ArrayView<const int16_t>(playout_buffer_.data(), samples_out));
+      if (!keep_rendering) {
+        rendering_ = false;
+        done_rendering_.Set();
+      }
+    }
+  }
+  tick_->Wait(WEBRTC_EVENT_INFINITE);
+}
+
+}  // namespace node_webrtc

--- a/src/webrtc/fake_audio_device.h
+++ b/src/webrtc/fake_audio_device.h
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2013 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+#ifndef WEBRTC_TEST_FAKE_AUDIO_DEVICE_H_
+#define WEBRTC_TEST_FAKE_AUDIO_DEVICE_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "webrtc/base/array_view.h"
+#include "webrtc/base/buffer.h"
+#include "webrtc/base/criticalsection.h"
+#include "webrtc/base/event.h"
+#include "webrtc/base/platform_thread.h"
+#include "webrtc/modules/audio_device/include/fake_audio_device.h"
+#include "webrtc/typedefs.h"
+
+namespace webrtc {
+
+class EventTimerWrapper;
+
+}  // namespace webrtc
+
+namespace node_webrtc {
+
+// FakeAudioDevice implements an AudioDevice module that can act both as a
+// capturer and a renderer. It will use 10ms audio frames.
+class FakeAudioDevice : public webrtc::FakeAudioDeviceModule {
+ public:
+  // Returns the number of samples that Capturers and Renderers with this
+  // sampling frequency will work with every time Capture or Render is called.
+  static size_t SamplesPerFrame(int sampling_frequency_in_hz);
+
+  class Capturer {
+   public:
+    virtual ~Capturer() {}
+    // Returns the sampling frequency in Hz of the audio data that this
+    // capturer produces.
+    virtual int SamplingFrequency() const = 0;
+    // Replaces the contents of |buffer| with 10ms of captured audio data
+    // (see FakeAudioDevice::SamplesPerFrame). Returns true if the capturer can
+    // keep producing data, or false when the capture finishes.
+    virtual bool Capture(rtc::BufferT<int16_t>* buffer) = 0;
+  };
+
+  class Renderer {
+   public:
+    virtual ~Renderer() {}
+    // Returns the sampling frequency in Hz of the audio data that this
+    // renderer receives.
+    virtual int SamplingFrequency() const = 0;
+    // Renders the passed audio data and returns true if the renderer wants
+    // to keep receiving data, or false otherwise.
+    virtual bool Render(rtc::ArrayView<const int16_t> data) = 0;
+  };
+
+  // Creates a new FakeAudioDevice. When capturing or playing, 10 ms audio
+  // frames will be processed every 10ms / |speed|.
+  // |capturer| is an object that produces audio data. Can be nullptr if this
+  // device is never used for recording.
+  // |renderer| is an object that receives audio data that would have been
+  // played out. Can be nullptr if this device is never used for playing.
+  // Use one of the Create... functions to get these instances.
+  FakeAudioDevice(std::unique_ptr<Capturer> capturer,
+      std::unique_ptr<Renderer> renderer,
+      float speed = 1);
+  ~FakeAudioDevice() override;
+
+  // Returns a Capturer instance that generates a signal where every second
+  // frame is zero and every second frame is evenly distributed random noise
+  // with max amplitude |max_amplitude|.
+  static std::unique_ptr<Capturer> CreatePulsedNoiseCapturer(
+      int16_t max_amplitude, int sampling_frequency_in_hz);
+
+  // Returns a Capturer instance that gets its data from a file.
+  static std::unique_ptr<Capturer> CreateWavFileReader(
+      std::string filename, int sampling_frequency_in_hz);
+
+  // Returns a Capturer instance that gets its data from a file.
+  // Automatically detects sample rate.
+  static std::unique_ptr<Capturer> CreateWavFileReader(std::string filename);
+
+  // Returns a Renderer instance that writes its data to a file.
+  static std::unique_ptr<Renderer> CreateWavFileWriter(
+      std::string filename, int sampling_frequency_in_hz);
+
+  // Returns a Renderer instance that writes its data to a WAV file, cutting
+  // off silence at the beginning (not necessarily perfect silence, see
+  // kAmplitudeThreshold) and at the end (only actual 0 samples in this case).
+  static std::unique_ptr<Renderer> CreateBoundedWavFileWriter(
+      std::string filename, int sampling_frequency_in_hz);
+
+  // Returns a Renderer instance that does nothing with the audio data.
+  static std::unique_ptr<Renderer> CreateDiscardRenderer(
+      int sampling_frequency_in_hz);
+
+  int32_t Init() override;
+  int32_t RegisterAudioCallback(webrtc::AudioTransport* callback) override;
+
+  int32_t StartPlayout() override;
+  int32_t StopPlayout() override;
+  int32_t StartRecording() override;
+  int32_t StopRecording() override;
+
+  bool Playing() const override;
+  bool Recording() const override;
+
+  // Blocks until the Renderer refuses to receive data.
+  // Returns false if |timeout_ms| passes before that happens.
+  bool WaitForPlayoutEnd(int timeout_ms = rtc::Event::kForever);
+  // Blocks until the Recorder stops producing data.
+  // Returns false if |timeout_ms| passes before that happens.
+  bool WaitForRecordingEnd(int timeout_ms = rtc::Event::kForever);
+
+ private:
+  static bool Run(void* obj);
+  void ProcessAudio();
+
+  const std::unique_ptr<Capturer> capturer_ GUARDED_BY(lock_);
+  const std::unique_ptr<Renderer> renderer_ GUARDED_BY(lock_);
+  const float speed_;
+
+  rtc::CriticalSection lock_;
+  webrtc::AudioTransport* audio_callback_ GUARDED_BY(lock_);
+  bool rendering_ GUARDED_BY(lock_);
+  bool capturing_ GUARDED_BY(lock_);
+  rtc::Event done_rendering_;
+  rtc::Event done_capturing_;
+
+  std::vector<int16_t> playout_buffer_ GUARDED_BY(lock_);
+  rtc::BufferT<int16_t> recording_buffer_ GUARDED_BY(lock_);
+
+  std::unique_ptr<webrtc::EventTimerWrapper> tick_;
+  rtc::PlatformThread thread_;
+};
+
+}  // namespace node_webrtc
+
+#endif  // WEBRTC_TEST_FAKE_AUDIO_DEVICE_H_

--- a/src/zerocapturer.h
+++ b/src/zerocapturer.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2018 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#ifndef SRC_ZERO_CAPTURER_H_
+#define SRC_ZERO_CAPTURER_H_
+
+#include <memory>
+
+#include "src/webrtc/fake_audio_device.h"
+
+namespace node_webrtc {
+
+class ZeroCapturer: public node_webrtc::FakeAudioDevice::Capturer {
+ public:
+  ZeroCapturer(int sampling_frequency_in_hz): _sampling_frequency_in_hz(sampling_frequency_in_hz) {}
+
+  virtual int SamplingFrequency() const {
+    return _sampling_frequency_in_hz;
+  }
+
+  virtual bool Capture(rtc::BufferT<int16_t>*) {
+    return false;
+  }
+
+  static std::unique_ptr<ZeroCapturer> Create(int sampling_frequency_in_hz) {
+    return std::unique_ptr<ZeroCapturer>(new ZeroCapturer(sampling_frequency_in_hz));
+  }
+
+ private:
+  int _sampling_frequency_in_hz;
+};
+
+}  // namespace node_webrtc
+
+#endif  // SRC_ZERO_CAPTURER_H_


### PR DESCRIPTION
Some basic MediaStream support in this release, and a new MediaStreamTrack "relay" example! 🎉

```
node examples/loopback.server.js
```

<img width="832" alt="screen shot 2018-06-12 at 3 52 24 pm" src="https://user-images.githubusercontent.com/359154/41324033-1818de5e-6e67-11e8-9492-432537613a67.png">

Strangely, I don't receive audio, though. And `getStats` doesn't show any bytes received for the audio track. But video relay works.

**EDIT:** OK, the reason there's no audio is because of the ADM we instantiate (using `kDummyAudio`). I think we need something like the fake ADM we previously used. Some other notes:

1. We probably don't want `kPlatformDefaultAudio`, since that will cause Node to playback audio.
2. We need to ensure we don't regress CPU utilization for RTCDataChannel-only applications, i.e. node-webrtc with RTCDataChannels only should continue to use the same amount of CPU, even if enabling audio utilizes more CPU.

**EDIT 2:** I imported FakeAudioDevice from `webrtc/test` into `src/webrtc` (like I did the PhysicalSocketServer code) and introduced ZeroCapturer. With these two in place, I see CPU usage comparable to using `kDummyAudio` and I get audio in the loopback example.

**EDIT 3:** There's an annoying Windows issue I need to fix. As best I can tell, somewhere, `timeSetEvent` returns `nullptr`.

**EDIT 4:** I want to release this, so I'm simply going to let Windows continue using `kDummyAudio`. This means audio relay will not work on Windows, so I'll add a caveat to the CHANGELOG.md.