### PR TITLE
Destroy AudioDeviceModule on worker thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.2.2
+=====
+
+Bug Fixes
+---------
+
+- Destroy AudioDeviceModule on the worker thread.
+
 0.2.1
 =====
 

--- a/src/peerconnectionfactory.cc
+++ b/src/peerconnectionfactory.cc
@@ -95,12 +95,15 @@ PeerConnectionFactory::~PeerConnectionFactory() {
 
   _factory = nullptr;
 
+  _workerThread->Invoke<void>(RTC_FROM_HERE, [this]() {
+    this->_audioDeviceModule = nullptr;
+  });
+
   _workerThread->Stop();
   _signalingThread->Stop();
 
   _workerThread = nullptr;
   _signalingThread = nullptr;
-  _audioDeviceModule = nullptr;
 
   _networkManager = nullptr;
   _socketFactory = nullptr;


### PR DESCRIPTION
I noticed this issue when running a debug build of WebRTC.