### PR TITLE
Support arm64/aarch64 native build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,6 @@ list(APPEND GN_GEN_ARGS
   rtc_include_pulse_audio=false
   rtc_include_tests=false
 )
-
 if ("$ENV{TARGET_ARCH}" STREQUAL "arm")
   list(APPEND GN_GEN_ARGS
     target_os="linux"
@@ -52,11 +51,20 @@ if ("$ENV{TARGET_ARCH}" STREQUAL "arm")
     fatal_linker_warnings=false
   )
 else()
-  list(APPEND GN_GEN_ARGS
-    rtc_build_tools=false
-  )
+  if ("$ENV{TARGET_ARCH}" STREQUAL "arm64")
+    list(APPEND GN_GEN_ARGS
+      target_os="linux"
+      target_cpu="arm64"
+      rtc_build_tools=true
+      treat_warnings_as_errors=false
+      fatal_linker_warnings=false
+    )
+  else()
+    list(APPEND GN_GEN_ARGS
+      rtc_build_tools=false
+    )
+  endif()
 endif()
-
 if (WIN32)
   list(APPEND GN_GEN_ARGS is_clang=false)
 endif()
@@ -353,7 +361,7 @@ else()
       -nostdinc++
       -nodefaultlibs
     )
-
+    
     if ("$ENV{TARGET_ARCH}" STREQUAL "arm")
       target_compile_options(${MODULE} PRIVATE
         -march=armv7-a
@@ -376,11 +384,30 @@ else()
       set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
       set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
     else()
-      target_compile_options(${MODULE} PRIVATE
-        -B${libwebrtc_source_dir}/src/third_party/binutils/Linux_x64/Release/bin
-        --sysroot=${libwebrtc_source_dir}/src/build/linux/debian_sid_amd64-sysroot
-      )
-    endif()    
+      if ("$ENV{TARGET_ARCH}" STREQUAL "arm64")
+        target_compile_options(${MODULE} PRIVATE
+        )
+  
+        set(CMAKE_SYSTEM_NAME Linux)
+        set(CMAKE_SYSTEM_PROCESSOR arm64)
+        
+        set(CMAKE_SYSROOT ${libwebrtc_source_dir}/src/build/linux/debian_sid_arm64-sysroot)
+  
+        set(tools $ENV{ARM_TOOLS_PATH})
+        set(CMAKE_C_COMPILER ${tools}/bin/aarch64-linux-gnu-gcc)
+        set(CMAKE_CXX_COMPILER ${tools}/bin/aarch64-linux-gnu-g++)
+  
+        set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+        set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+        set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+        set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+      else()
+        target_compile_options(${MODULE} PRIVATE
+          -B${libwebrtc_source_dir}/src/third_party/binutils/Linux_x64/Release/bin
+          --sysroot=${libwebrtc_source_dir}/src/build/linux/debian_sid_amd64-sysroot
+        )
+      endif()
+    endif()
   endif()
 endif()
 

--- a/scripts/configure-webrtc.sh
+++ b/scripts/configure-webrtc.sh
@@ -11,7 +11,10 @@ cd ${SOURCE_DIR}
 if [ "$TARGET_ARCH" == "arm" ]; then
   python build/linux/sysroot_scripts/install-sysroot.py --arch=arm
 else
-  python build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
+  if [ "$TARGET_ARCH" == "arm64" ]; then
+    python build/linux/sysroot_scripts/install-sysroot.py --arch=arm64
+  else
+    python build/linux/sysroot_scripts/install-sysroot.py --arch=amd64
+  fi
 fi
-
 gn gen ${BINARY_DIR} "--args=${GN_GEN_ARGS}"


### PR DESCRIPTION

wget https://releases.linaro.org/components/toolchain/binaries/latest-7/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
tar xf gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
SKIP_DOWNLOAD=true TARGET_ARCH=arm64 ARM_TOOLS_PATH=$(pwd)/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu npm install