### PR TITLE
Added ability to set .enabled on MediaStreamTrack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+0.3.5
+=====
+
+New Features
+------------
+
+- Added support for setting MediaStreamTrack's `enabled` property (#475).
+
 0.3.4
 =====
 

--- a/src/asyncobjectwrapwithloop.h
+++ b/src/asyncobjectwrapwithloop.h
@@ -95,7 +95,7 @@ class AsyncObjectWrapWithLoop
   /**
    * Stop the event loop.
    */
-  void Stop() {
+  virtual void Stop() {
     PromiseFulfillingEventLoop<T>::Stop();
   }
 };

--- a/src/eventloop.h
+++ b/src/eventloop.h
@@ -87,7 +87,7 @@ class EventLoop: private EventQueue<T> {
   /**
    * Stop the EventLoop.
    */
-  void Stop() {
+  virtual void Stop() {
     _should_stop = true;
     Dispatch(Event<T>::Create());
   }

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -80,6 +80,16 @@ NAN_GETTER(MediaStreamTrack::GetEnabled) {
   info.GetReturnValue().Set(Nan::New(self->_track->enabled()));
 }
 
+NAN_SETTER(MediaStreamTrack::SetEnabled) {
+  (void) property;
+
+  auto self = AsyncObjectWrapWithLoop<MediaStreamTrack>::Unwrap(info.Holder());
+
+  CONVERT_OR_THROW_AND_RETURN(value, enabled, boolean_t);
+
+  self->_track->set_enabled(enabled);
+}
+
 NAN_GETTER(MediaStreamTrack::GetId) {
   (void) property;
   auto self = AsyncObjectWrapWithLoop<MediaStreamTrack>::Unwrap(info.Holder());
@@ -177,7 +187,7 @@ void MediaStreamTrack::Init(Handle<Object> exports) {
   MediaStreamTrack::tpl().Reset(tpl);
   tpl->SetClassName(Nan::New("MediaStreamTrack").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
-  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("enabled").ToLocalChecked(), GetEnabled, nullptr);
+  Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("enabled").ToLocalChecked(), GetEnabled, SetEnabled);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("id").ToLocalChecked(), GetId, nullptr);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("kind").ToLocalChecked(), GetKind, nullptr);
   Nan::SetAccessor(tpl->InstanceTemplate(), Nan::New("readyState").ToLocalChecked(), GetReadyState, nullptr);

--- a/src/mediastreamtrack.cc
+++ b/src/mediastreamtrack.cc
@@ -85,7 +85,7 @@ NAN_SETTER(MediaStreamTrack::SetEnabled) {
 
   auto self = AsyncObjectWrapWithLoop<MediaStreamTrack>::Unwrap(info.Holder());
 
-  CONVERT_OR_THROW_AND_RETURN(value, enabled, boolean_t);
+  CONVERT_OR_THROW_AND_RETURN(value, enabled, bool);
 
   self->_track->set_enabled(enabled);
 }

--- a/src/mediastreamtrack.h
+++ b/src/mediastreamtrack.h
@@ -47,6 +47,9 @@ class MediaStreamTrack
 
   static Nan::Persistent<v8::FunctionTemplate>& tpl();
 
+ protected:
+  void Stop() override;
+
  private:
   MediaStreamTrack(
       std::shared_ptr<node_webrtc::PeerConnectionFactory>&& factory,
@@ -71,6 +74,7 @@ class MediaStreamTrack
   static NAN_METHOD(JsStop);
 
   bool _ended;
+  bool _enabled;
   const std::shared_ptr<node_webrtc::PeerConnectionFactory> _factory;
   const rtc::scoped_refptr<webrtc::MediaStreamTrackInterface> _track;
 };

--- a/src/mediastreamtrack.h
+++ b/src/mediastreamtrack.h
@@ -61,6 +61,7 @@ class MediaStreamTrack
   static NAN_METHOD(New);
 
   static NAN_GETTER(GetEnabled);
+  static NAN_SETTER(SetEnabled);
   static NAN_GETTER(GetId);
   static NAN_GETTER(GetKind);
   static NAN_GETTER(GetReadyState);

--- a/test/mediastream.js
+++ b/test/mediastream.js
@@ -174,6 +174,9 @@ tape('.enabled on MediaStreamTrack', function(t) {
     t.ok(tracks.every(function(track) {
       return track.enabled;
     }), 'all MediaStreamTracks are enabled again');
+    tracks.forEach(function(track) {
+      track.stop();
+    });
     t.end();
   });
 });

--- a/test/mediastream.js
+++ b/test/mediastream.js
@@ -159,6 +159,25 @@ tape('.removeTrack and .addTrack on remote MediaStream', function(t) {
   });
 });
 
+tape('.enabled on MediaStreamTrack', function(t) {
+  return getMediaStream().then(function(stream) {
+    var tracks = stream.getTracks();
+    tracks.forEach(function(track) {
+      track.enabled = false;
+    });
+    t.ok(tracks.every(function(track) {
+      return !track.enabled;
+    }), 'enabled is false on all MediaStreamTracks');
+    tracks.forEach(function(track) {
+      track.enabled = true;
+    });
+    t.ok(tracks.every(function(track) {
+      return track.enabled;
+    }), 'all MediaStreamTracks are enabled again');
+    t.end();
+  });
+});
+
 function getMediaStream() {
   var pc = new RTCPeerConnection();
   var offer = new RTCSessionDescription({ type: 'offer', sdp: sdp });

--- a/test/mediastream.js
+++ b/test/mediastream.js
@@ -50,7 +50,7 @@ tape('new MediaStream()', function(t) {
 });
 
 tape('new MediaStream(stream)', function(t) {
-  return getMediaStream().then(function(stream1) {
+  return getRemoteMediaStream().then(function(stream1) {
     var stream2 = new MediaStream(stream1);
     t.notEqual(stream2.id, stream1.id, 'the MediaStream .ids do not match');
     t.ok(stream2.getTracks().every(function(track, i) {
@@ -63,7 +63,7 @@ tape('new MediaStream(stream)', function(t) {
 });
 
 tape('new MediaStream(tracks)', function(t) {
-  return getMediaStream().then(function(stream1) {
+  return getRemoteMediaStream().then(function(stream1) {
     var tracks = stream1.getTracks();
     var stream2 = new MediaStream(tracks);
     t.ok(stream2.getTracks().every(function(track, i) {
@@ -76,7 +76,7 @@ tape('new MediaStream(tracks)', function(t) {
 });
 
 tape('.clone', function(t) {
-  return getMediaStream().then(function(stream1) {
+  return getRemoteMediaStream().then(function(stream1) {
     var stream2 = stream1.clone();
     var stream3 = stream2.clone();
     // NOTE(mroberts): Weirdly, cloned video MediaStreamTracks have .readyState
@@ -142,7 +142,7 @@ tape.skip('.clone and .stop', function(t) {
 });
 
 tape('.removeTrack and .addTrack on remote MediaStream', function(t) {
-  return getMediaStream().then(function(stream) {
+  return getRemoteMediaStream().then(function(stream) {
     var tracks = stream.getTracks();
     tracks.forEach(function(track) {
       stream.removeTrack(track);
@@ -159,29 +159,37 @@ tape('.removeTrack and .addTrack on remote MediaStream', function(t) {
   });
 });
 
-tape('.enabled on MediaStreamTrack', function(t) {
-  return getMediaStream().then(function(stream) {
-    var tracks = stream.getTracks();
-    tracks.forEach(function(track) {
-      track.enabled = false;
-    });
-    t.ok(tracks.every(function(track) {
-      return !track.enabled;
-    }), 'enabled is false on all MediaStreamTracks');
-    tracks.forEach(function(track) {
-      track.enabled = true;
-    });
-    t.ok(tracks.every(function(track) {
-      return track.enabled;
-    }), 'all MediaStreamTracks are enabled again');
-    tracks.forEach(function(track) {
-      track.stop();
-    });
-    t.end();
-  });
+function testSettingEnabled(t, stream) {
+  const tracks = stream.getTracks();
+
+  tracks.forEach(track => { track.enabled = false; });
+  t.ok(tracks.every(track => !track.enabled),
+    'enabled can initially be set to false on all MediaStreamTracks');
+
+  tracks.forEach(track => { track.enabled = true; });
+  t.ok(tracks.every(track => track.enabled),
+    'enabled can then be set to true on all MediaStreamTracks');
+
+  tracks.forEach(track => track.stop());
+  t.ok(tracks.every(track => track.enabled),
+    'enabled remains true for all MediaStreamTracks after stopping');
+
+  tracks.forEach(track => { track.enabled = false; });
+  t.ok(tracks.every(track => !track.enabled),
+    'enabled can still be set on stopped MediaStreamTracks');
+
+  t.end();
+}
+
+tape('.enabled on local MediaStreamTrack', t => {
+  getLocalMediaStream().then(stream => testSettingEnabled(t, stream));
 });
 
-function getMediaStream() {
+tape('.enabled on remote MediaStreamTrack', t => {
+  getRemoteMediaStream().then(stream => testSettingEnabled(t, stream));
+});
+
+function getRemoteMediaStream() {
   var pc = new RTCPeerConnection();
   var offer = new RTCSessionDescription({ type: 'offer', sdp: sdp });
   var trackEventPromise = new Promise(function(resolve) {
@@ -193,4 +201,8 @@ function getMediaStream() {
     pc.close();
     return trackEvent.streams[0];
   });
+}
+
+function getLocalMediaStream() {
+  return getUserMedia({ audio: true, video: true });
 }


### PR DESCRIPTION
See #475. Useful for mute-like functionality [as per the WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled).