### PR TITLE
Allow node to access the VideoFrame rotation

### DIFF
--- a/src/converters/dictionaries.cc
+++ b/src/converters/dictionaries.cc
@@ -752,6 +752,7 @@ TO_JS_IMPL(webrtc::VideoFrame, value) {
   auto frame = Nan::New<v8::Object>();
   frame->Set(Nan::New("width").ToLocalChecked(), node_webrtc::From<v8::Local<v8::Value>>(value.width()).UnsafeFromValid());
   frame->Set(Nan::New("height").ToLocalChecked(), node_webrtc::From<v8::Local<v8::Value>>(value.height()).UnsafeFromValid());
+  frame->Set(Nan::New("rotation").ToLocalChecked(), node_webrtc::From<v8::Local<v8::Value>>(static_cast<int>(value.rotation())).UnsafeFromValid());
   auto maybeData = node_webrtc::From<v8::Local<v8::Value>>(value.video_frame_buffer());
   if (maybeData.IsInvalid()) {
     return node_webrtc::Validation<v8::Local<v8::Value>>::Invalid(maybeData.ToErrors()[0]);


### PR DESCRIPTION
The `frame` object on the node.js side, retrieved from `RTCVideoSink`, contains the following elements:
- width
- height
- data

This commit adds a 4th element `rotation`, to get the video orientation from the node.js code.
