### PR TITLE
Add support for EventListener.handleEvent()

### DIFF
--- a/lib/eventtarget.js
+++ b/lib/eventtarget.js
@@ -28,8 +28,14 @@ function EventTarget() {
         listenerArray = listenerArray.concat(dummyListener);
       }
 
-      for (var i = 0, l = listenerArray.length; i < l; i++) {
-        listenerArray[i].call(self, event);
+      for (var i = 0, l = listenerArray.length, listener; i < l; i++) {
+        listener = listenerArray[i];
+        if (typeof listener === 'object' && typeof listener.handleEvent === 'function') {
+          listener.handleEvent(event);
+        }
+        else {
+          listener.call(self, event);
+        }
       }
     });
   };


### PR DESCRIPTION
Some folk (like myself) [use `handleEvent` to avoid context binding](https://medium.com/@WebReflection/dom-handleevent-a-cross-platform-standard-since-year-2000-5bf17287fd38), and this pull request enables the pattern in your `EventTarget` implementation.

I’ve attempted to match the project style, but please let me know if there are issues.