### PR TITLE
Fix addIceCandidate queueing behavior

### DIFF
--- a/src/events.cc
+++ b/src/events.cc
@@ -12,6 +12,7 @@
 #include "src/rtcaudiosink.h"
 #include "src/rtcvideosink.h"
 
+using node_webrtc::AddIceCandidateEvent;
 using node_webrtc::DataChannel;
 using node_webrtc::DataChannelEvent;
 using node_webrtc::DataChannelStateChangeEvent;
@@ -25,6 +26,7 @@ using node_webrtc::OnAddTrackEvent;
 using node_webrtc::OnDataEvent;
 using node_webrtc::OnFrameEvent;
 using node_webrtc::PeerConnection;
+using node_webrtc::PromiseEvent;
 using node_webrtc::RTCAudioSink;
 using node_webrtc::RTCVideoSink;
 using node_webrtc::SignalingStateChangeEvent;
@@ -61,6 +63,11 @@ void OnAddTrackEvent::Dispatch(PeerConnection& peerConnection) {
 
 void IceEvent::Dispatch(PeerConnection& peerConnection) {
   peerConnection.HandleIceCandidateEvent(*this);
+}
+
+void AddIceCandidateEvent::Dispatch(PeerConnection& peerConnection) {
+  peerConnection.HandleAddIceCandidateEvent(*this);
+  PromiseEvent<PeerConnection>::Dispatch(peerConnection);
 }
 
 void IceConnectionStateChangeEvent::Dispatch(PeerConnection& peerConnection) {

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -30,6 +30,7 @@ class RtpTransceiverInterface;
 
 namespace node_webrtc {
 
+class AddIceCandidateEvent;
 class IceConnectionStateChangeEvent;
 class IceEvent;
 class IceGatheringStateChangeEvent;
@@ -68,6 +69,7 @@ class PeerConnection
   //
   static void Init(v8::Handle<v8::Object> exports);
 
+  void HandleAddIceCandidateEvent(AddIceCandidateEvent& event);
   void HandleIceConnectionStateChangeEvent(const IceConnectionStateChangeEvent& event);
   void HandleIceGatheringStateChangeEvent(const IceGatheringStateChangeEvent& event);
   void HandleIceCandidateEvent(const IceEvent& event);

--- a/test/addicecandidate.js
+++ b/test/addicecandidate.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('tape');
+
+const { RTCPeerConnection } = require('..');
+
+const offer = {
+  type: 'offer',
+  sdp: `\
+v=0
+o=- 2327044227424838191 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS
+m=application 9 DTLS/SCTP 5000
+c=IN IP4 0.0.0.0
+a=ice-ufrag:ZVjA
+a=ice-pwd:ySFnYuYDmL6hstu0f3kgG71w
+a=ice-options:trickle
+a=fingerprint:sha-256 BD:08:3B:BA:84:0F:E7:0B:CD:61:FD:EA:E7:F1:31:62:14:52:43:DB:CB:5D:1C:60:53:0E:E1:7C:87:41:56:FD
+a=setup:actpass
+a=mid:0
+a=sctpmap:5000 webrtc-datachannel 1024
+`.split('\n').join('\r\n')
+};
+
+const candidate = {
+  candidate: 'candidate:559267639 1 udp 2122267903 ::1 57693 typ host generation 0 ufrag ZVjA network-id 2',
+  sdpMid: '0',
+  sdpMLineIndex: 0
+};
+
+test('addIceCandidate', t => {
+  test('has correct queueing behavior', t => {
+    const pc = new RTCPeerConnection();
+    return Promise.all([
+      pc.setRemoteDescription(offer),
+      pc.addIceCandidate(candidate)
+    ]).then(() => {
+      pc.close();
+      t.pass('addIceCandidate worked correctly');
+      t.end();
+    });
+  });
+
+  t.end();
+});

--- a/test/all.js
+++ b/test/all.js
@@ -2,6 +2,7 @@
 
 const semver = require('semver');
 
+require('./addicecandidate');
 require('./closing-data-channel');
 require('./closing-peer-connection');
 require('./connect');


### PR DESCRIPTION
Fixes #498. It may also improve #489. `AddIceCandidate` is now called in `node_webrtc::PeerConnection`'s event loop, which means code like the following should now work:

```js
pc.setRemoteDescription(description);
pc.addIceCandidate(candidate);
```

Previously, this would typically fail, since, in the C++ layer, `AddIceCandidate` executed synchronously before `setRemoteDescription` resolves (hence `remoteDescription` is still null or otherwise out-of-date). Now, the `AddIceCandidate` call will queue up behind `setRemoteDescription`.

cc @t-mullen