### PR TITLE
Make node-webrtc citgm-friendly

### DIFF
--- a/docs/build-from-source.md
+++ b/docs/build-from-source.md
@@ -15,16 +15,16 @@ required by node-cmake, you will need
 
 ## Install
 
-Once you have the prerequisites, clone the repository and run `npm install`.
-This `npm install` will trigger the initial build. Just like when installing
-prebuilt binaries, you can set the `TARGET_ARCH` environment variable to "arm"
-or "arm64" to build for armv7l or arm64, respectively. Linux and macOS users can
-also set the `DEBUG` environment variable for debug builds.
+Once you have the prerequisites, clone the repository, set the `SKIP_DOWNLOAD`
+environment variable to "true", and run `npm install`. Just like when
+installing prebuilt binaries, you can set the `TARGET_ARCH` environment
+variable to "arm" or "arm64" to build for armv7l or arm64, respectively. Linux
+and macOS users can also set the `DEBUG` environment variable for debug builds.
 
 ```
 git clone https://github.com/node-webrtc/node-webrtc.git
 cd node-webrtc
-npm install
+SKIP_DOWNLOAD=true npm install
 ```
 
 ## Subsequent Builds
@@ -59,7 +59,7 @@ In order to cross-compile for armv7l on Linux,
 ```
 wget https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/arm-linux-gnueabihf/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf.tar.xz
 tar xf gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf.tar.xz
-TARGET_ARCH=arm ARM_TOOLS_PATH=$(pwd)/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf npm install
+SKIP_DOWNLOAD=true TARGET_ARCH=arm ARM_TOOLS_PATH=$(pwd)/gcc-linaro-7.3.1-2018.05-x86_64_arm-linux-gnueabihf npm install
 ```
 
 #### arm64
@@ -73,7 +73,7 @@ In order to cross-compile for arm64 on Linux,
 ```
 wget https://releases.linaro.org/components/toolchain/binaries/7.3-2018.05/aarch64-linux-gnu/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
 tar xf gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu.tar.xz
-TARGET_ARCH=arm64 ARM_TOOLS_PATH=$(pwd)/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu npm install
+SKIP_DOWNLOAD=true TARGET_ARCH=arm64 ARM_TOOLS_PATH=$(pwd)/gcc-linaro-7.3.1-2018.05-x86_64_aarch64-linux-gnu npm install
 ```
 
 ### macOS

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ws": "^5.2.0"
   },
   "scripts": {
-    "install": "node scripts/build-from-source.js",
+    "install": "node scripts/download-prebuilt-or-build-from-source.js",
     "install-example": "node scripts/install-example.js",
     "lint": "eslint lib/*.js lib/**/*.js test/*.js test/**/*.js karma/*.js scripts/*.js",
     "publish-binary": "node scripts/publish.js",

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -6,6 +6,7 @@ powershell Install-Product node $env:nodejs_version x64
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO npm install
+SET SKIP_DOWNLOAD=true
 CALL npm install
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 

--- a/scripts/build-from-source.js
+++ b/scripts/build-from-source.js
@@ -39,4 +39,8 @@ function main() {
   console.log('Built wrtc');
 }
 
-main();
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/download-prebuilt-or-build-from-source.js
+++ b/scripts/download-prebuilt-or-build-from-source.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint no-console:0, no-process-env:0 */
+
+const build = require('./build-from-source');
+const download = require('./download-prebuilt');
+
+function main() {
+  if (!process.env.SKIP_DOWNLOAD) {
+    try {
+      console.log('Searching for a pre-built wrtc binary');
+      download();
+      console.log('Installed a pre-built wrtc binary');
+      return;
+    } catch (error) {
+      console.log('Unable to install a pre-built wrtc binary; falling back to ncmake');
+    }
+  }
+  build();
+}
+
+main();

--- a/scripts/download-prebuilt.js
+++ b/scripts/download-prebuilt.js
@@ -24,4 +24,8 @@ function main() {
   }
 }
 
-main();
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
citgm is Node.js's "Canary in the Gold Mine". It tests Node.js libraries against Node.js "releases and controversial changes". Getting into this project ought to help protect node-webrtc from breaking changes in future Node.js releases, especially with regards to N-API.

One of the requirements is that packages are testable by cloning from GitHub and then running `npm install && npm test`. This PR reintroduces that behavior.