### PR TITLE
Don't signal iceGatheringState complete if connection closed

### DIFF
--- a/lib/peerconnection.js
+++ b/lib/peerconnection.js
@@ -60,7 +60,7 @@ function RTCPeerConnection() {
     self.dispatchEvent({ type: 'icegatheringstatechange' });
 
     // if we have completed gathering candidates, trigger a null candidate event
-    if (self.iceGatheringState === 'complete') {
+    if (self.iceGatheringState === 'complete' && self.connectionState !== 'closed') {
       self.dispatchEvent(new RTCPeerConnectionIceEvent('icecandidate', { candidate: null }));
     }
   };

--- a/test/closing-peer-connection.js
+++ b/test/closing-peer-connection.js
@@ -59,3 +59,20 @@ test('make sure channel is available after after connection is closed on the oth
       peer1.setRemoteDescription(peer2.localDescription);
     });
 });
+
+
+test('make sure onicecandidate handler doesn\'t fire when connection is closed', function(t) {
+  t.plan(1);
+
+  var peer = new RTCPeerConnection({ iceServers: [] });
+
+  pc.onicecandidate = function () {
+    t.ok(false, 'should not have fired');
+  };
+
+  pc.close();
+
+  setTimeout(function() {
+    t.ok(true, 'other t did not fire');
+  }, 100);
+});


### PR DESCRIPTION
Note that, although this adds a test, I didn't actually try running it :)

This only happens internal to node-webrtc,
https://chromium.googlesource.com/external/webrtc/+/branch-heads/m79/pc/peer_connection.cc#4385
