### PR TITLE
Added missing apis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+sudo: false
+language: node_js
+dist: trusty
+node_js:
+- "7"
+
+env:
+  - CXX=g++-4.8
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      env: BROWSER=chrome  BVER=stable
+    - os: linux
+      sudo: false
+      env: BROWSER=chrome  BVER=beta
+    - os: linux
+      sudo: false
+      env: BROWSER=chrome  BVER=unstable
+    - os: linux
+      sudo: false
+      env: BROWSER=firefox BVER=stable
+    - os: linux
+      sudo: false
+      env: BROWSER=firefox BVER=beta
+    - os: linux
+      sudo: false
+      env: BROWSER=firefox BVER=unstable
+    - os: osx
+      sudo: required
+      osx_image: xcode9.4
+      env: BROWSER=safari BVER=stable
+    - os: osx
+      sudo: required
+      osx_image: xcode11.2
+      env: BROWSER=safari BVER=unstable
+
+  fast_finish: true
+
+  allow_failures:
+    - os: linux
+      sudo: false
+      env: BROWSER=chrome  BVER=unstable
+    - os: linux
+      sudo: false
+      env: BROWSER=firefox BVER=unstable
+
+before_script:
+  - ./node_modules/travis-multirunner/setup.sh
+  - export DISPLAY=:99.0
+  - if [ -f /etc/init.d/xvfb ]; then sh -e /etc/init.d/xvfb start; fi
+
+after_failure:
+  - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
+
+notifications:
+  email:
+  - ack@modeswitch.org
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,6 +1,17 @@
 'use strict';
 
 exports.MediaStream = window.MediaStream;
+exports.MediaStreamTrack = window.MediaStreamTrack;
+exports.RTCDataChannel = window.RTCDataChannel;
+exports.RTCDataChannelEvent = window.RTCDataChannelEvent;
+exports.RTCDtlsTransport = window.RTCDtlsTransport;
 exports.RTCIceCandidate = window.RTCIceCandidate;
+exports.RTCIceTransport = window.RTCIceTransport;
 exports.RTCPeerConnection = window.RTCPeerConnection;
+exports.RTCPeerConnectionIceEvent = window.RTCPeerConnectionIceEvent;
+exports.RTCRtpReceiver = window.RTCRtpReceiver;
+exports.RTCRtpSender = window.RTCRtpSender;
+exports.RTCRtpTransceiver = window.RTCRtpTransceiver;
+exports.RTCSctpTransport = window.RTCSctpTransport;
 exports.RTCSessionDescription = window.RTCSessionDescription;
+exports.getUserMedia = window.getUserMedia;

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -15,3 +15,4 @@ exports.RTCRtpTransceiver = window.RTCRtpTransceiver;
 exports.RTCSctpTransport = window.RTCSctpTransport;
 exports.RTCSessionDescription = window.RTCSessionDescription;
 exports.getUserMedia = window.getUserMedia;
+exports.mediaDevices = navigator.mediaDevices;

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ const {
 } = require('./binding');
 
 const EventTarget = require('./eventtarget');
+const MediaDevices = require('./mediadevices');
 
 inherits(MediaStream, EventTarget);
 inherits(MediaStreamTrack, EventTarget);
@@ -47,6 +48,8 @@ RTCDataChannel.prototype.send = function send(data) {
   }
   this._send(data);
 };
+
+const mediaDevices = new MediaDevices();
 
 const nonstandard = {
   i420ToRgba,
@@ -73,5 +76,6 @@ module.exports = {
   RTCSctpTransport,
   RTCSessionDescription: require('./sessiondescription'),
   getUserMedia,
+  mediaDevices,
   nonstandard,
 };

--- a/lib/mediadevices.js
+++ b/lib/mediadevices.js
@@ -2,7 +2,7 @@
 
 var inherits = require('util').inherits;
 
-const {getUserMedia} = require('./binding');
+const {getDisplayMedia, getUserMedia} = require('./binding');
 
 var EventTarget = require('./eventtarget');
 
@@ -18,10 +18,7 @@ MediaDevices.prototype.getSupportedConstraints = function getSupportedConstraint
   throw new Error("Not yet implemented; file a feature request against node-webrtc")
 };
 
-MediaDevices.prototype.getDisplayMedia = function getDisplayMedia(constraints) {
-  throw new Error("Not yet implemented; file a feature request against node-webrtc")
-};
-
+MediaDevices.prototype.getDisplayMedia = getDisplayMedia;
 MediaDevices.prototype.getUserMedia = getUserMedia;
 
 module.exports = MediaDevices;

--- a/lib/mediadevices.js
+++ b/lib/mediadevices.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var inherits = require('util').inherits;
+
+const {getUserMedia} = require('./binding');
+
+var EventTarget = require('./eventtarget');
+
+function MediaDevices() {}
+
+inherits(MediaDevices, EventTarget);
+
+MediaDevices.prototype.enumerateDevices = function enumerateDevices() {
+  throw new Error("Not yet implemented; file a feature request against node-webrtc")
+};
+
+MediaDevices.prototype.getSupportedConstraints = function getSupportedConstraints() {
+  throw new Error("Not yet implemented; file a feature request against node-webrtc")
+};
+
+MediaDevices.prototype.getDisplayMedia = function getDisplayMedia(constraints) {
+  throw new Error("Not yet implemented; file a feature request against node-webrtc")
+};
+
+MediaDevices.prototype.getUserMedia = getUserMedia;
+
+module.exports = MediaDevices;

--- a/lib/mediadevices.js
+++ b/lib/mediadevices.js
@@ -2,7 +2,7 @@
 
 var inherits = require('util').inherits;
 
-const {getDisplayMedia, getUserMedia} = require('./binding');
+const { getDisplayMedia, getUserMedia } = require('./binding');
 
 var EventTarget = require('./eventtarget');
 
@@ -11,11 +11,11 @@ function MediaDevices() {}
 inherits(MediaDevices, EventTarget);
 
 MediaDevices.prototype.enumerateDevices = function enumerateDevices() {
-  throw new Error("Not yet implemented; file a feature request against node-webrtc")
+  throw new Error('Not yet implemented; file a feature request against node-webrtc');
 };
 
 MediaDevices.prototype.getSupportedConstraints = function getSupportedConstraints() {
-  throw new Error("Not yet implemented; file a feature request against node-webrtc")
+  throw new Error('Not yet implemented; file a feature request against node-webrtc');
 };
 
 MediaDevices.prototype.getDisplayMedia = getDisplayMedia;

--- a/scripts/download-prebuilt.js
+++ b/scripts/download-prebuilt.js
@@ -4,7 +4,7 @@
 
 const { spawnSync } = require('child_process');
 
-function main() {
+function main(exit) {
   const args = ['install'];
 
   if (process.env.DEBUG) {
@@ -20,6 +20,10 @@ function main() {
     stdio: 'inherit'
   });
   if (status) {
+    if (!exit) {
+      throw new Error(status);
+    }
+
     process.exit(1);
   }
 }
@@ -27,5 +31,5 @@ function main() {
 module.exports = main;
 
 if (require.main === module) {
-  main();
+  main(true);
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -26,6 +26,7 @@
 #include "src/interfaces/rtc_stats_response.h"
 #include "src/interfaces/rtc_video_sink.h"
 #include "src/interfaces/rtc_video_source.h"
+#include "src/methods/get_display_media.h"
 #include "src/methods/get_user_media.h"
 #include "src/methods/i420_helpers.h"
 #include "src/node/async_context_releaser.h"
@@ -42,6 +43,7 @@ static void dispose(void*) {
 static Napi::Object Init(Napi::Env env, Napi::Object exports) {
   node_webrtc::AsyncContextReleaser::Init(env, exports);
   node_webrtc::ErrorFactory::Init(env, exports);
+  node_webrtc::GetDisplayMedia::Init(env, exports);
   node_webrtc::GetUserMedia::Init(env, exports);
   node_webrtc::I420Helpers::Init(env, exports);
   node_webrtc::LegacyStatsReport::Init(env, exports);

--- a/src/methods/get_display_media.cc
+++ b/src/methods/get_display_media.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2019 The node-webrtc project authors. All rights reserved.
+ *
+ * Use of this source code is governed by a BSD-style license that can be found
+ * in the LICENSE.md file in the root of the source tree. All contributing
+ * project authors may be found in the AUTHORS file in the root of the source
+ * tree.
+ */
+#include "src/methods/get_display_media.h"
+
+#include "src/methods/get_user_media.h"
+
+void node_webrtc::GetDisplayMedia::Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("getDisplayMedia", Napi::Function::New(env, GetUserMedia::GetUserMediaImpl));
+}

--- a/src/methods/get_display_media.h
+++ b/src/methods/get_display_media.h
@@ -9,19 +9,11 @@
 
 #include <node-addon-api/napi.h>
 
-// TODO Remove when `GetDisplayMedia` gets its own implementation
-#include "src/methods/get_display_media.h"
-
 namespace node_webrtc {
 
-class GetUserMedia {
- // TODO Remove when `GetDisplayMedia` gets its own implementation
- friend class node_webrtc::GetDisplayMedia;
+class GetDisplayMedia {
  public:
   static void Init(Napi::Env, Napi::Object);
-
- private:
-  static Napi::Value GetUserMediaImpl(const Napi::CallbackInfo&);
 };
 
 }  // namespace node_webrtc


### PR DESCRIPTION
This pull-request has some different inter-related changes, each one on its each commit, so they can be inspected separately:

- Added browser equivalent objects and functions of all project exported ones to `lib/browser.js` file
- Added a naïve version of `mediaDevices` to project exported objects (and export browser one in `lib/browser.js` file)
- Fix a bug where `scripts/download-prebuilt-or-build-from-source.js` was exiting if it didn't found a prebuild image, instead of trying to build the project
- Added a naïve implementation of `getDeviceMedia()` function that actually exec `GetUserMedia::GetUserMediaImpl` private function

Additionally, I've added a copy of the file `.travis.yml` that seems to be autogenerated, because I didn't written it but appeared as a new file, in case it's needed...