### PR TITLE
Use range to define `node` engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "host": "https://node-webrtc.s3.amazonaws.com"
   },
   "engines": {
-    "node": "^8.11.2 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
+    "node": "^8.11.2 || >=10.0.0"
   },
   "dependencies": {
     "nan": "^2.3.2",


### PR DESCRIPTION
Instead of adding new versions in `package.json` file `engines.node` field, use a range starting with Node.js 10.x, since we are targeting n-api. This change makes `node-webrtc` automatically compatible with any future Node.js version.