### PR TITLE
Replace node-pre-gyp with supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "node": "^8.11.2 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
   },
   "dependencies": {
+    "@mapbox/node-pre-gyp": "^1.0.4",
     "nan": "^2.3.2",
     "node-addon-api": "^1.6.2",
-    "node-cmake": "2.3.2",
-    "node-pre-gyp": "^0.13.0"
+    "node-cmake": "2.3.2"
   },
   "optionalDependencies": {
     "domexception": "^1.0.1"
   },
   "bundledDependencies": [
-    "node-pre-gyp"
+    "@mapbox/node-pre-gyp"
   ],
   "devDependencies": {
     "@fidm/x509": "^1.2.1",


### PR DESCRIPTION
`node-pre-gyp` has been deprecated and renamed `@mapbox/node-pre-gyp` but is otherwise API compatible so this change swaps the deps around.

`node-pre-gyp` will no longer receive updates - the `@mapbox` version has already seen a few new releases so should be what's used going forwards.

See the release notes: https://github.com/mapbox/node-pre-gyp/blob/HEAD/CHANGELOG.md#100

Fixes #682