### PR TITLE
Add toJSON function on RTCIceCandidate and RTCSessionDescription

### DIFF
--- a/lib/icecandidate.js
+++ b/lib/icecandidate.js
@@ -25,39 +25,18 @@ function RTCIceCandidate(candidateInitDict) {
   });
 
   this.toJSON = () => {
-    const {
+    const { candidate, sdpMid, sdpMLineIndex, usernameFragment } = this;
+    let json = {
       candidate,
       sdpMid,
-      sdpMLineIndex,
-      foundation,
-      component,
-      priority,
-      address,
-      protocol,
-      port,
-      type,
-      tcpType,
-      relatedAddress,
-      relatedPort,
-      usernameFragment
-    } = this;
-
-    return {
-      candidate,
-      sdpMid,
-      sdpMLineIndex,
-      foundation,
-      component,
-      priority,
-      address,
-      protocol,
-      port,
-      type,
-      tcpType,
-      relatedAddress,
-      relatedPort,
-      usernameFragment
+      sdpMLineIndex
     };
+
+    if (usernameFragment) {
+      json.usernameFragment = usernameFragment;
+    }
+
+    return json;
   };
 }
 

--- a/lib/icecandidate.js
+++ b/lib/icecandidate.js
@@ -23,6 +23,42 @@ function RTCIceCandidate(candidateInitDict) {
       this[property] = null;
     }
   });
+
+  this.toJSON = () => {
+    const {
+      candidate,
+      sdpMid,
+      sdpMLineIndex,
+      foundation,
+      component,
+      priority,
+      address,
+      protocol,
+      port,
+      type,
+      tcpType,
+      relatedAddress,
+      relatedPort,
+      usernameFragment
+    } = this;
+
+    return {
+      candidate,
+      sdpMid,
+      sdpMLineIndex,
+      foundation,
+      component,
+      priority,
+      address,
+      protocol,
+      port,
+      type,
+      tcpType,
+      relatedAddress,
+      relatedPort,
+      usernameFragment
+    };
+  };
 }
 
 module.exports = RTCIceCandidate;

--- a/lib/sessiondescription.js
+++ b/lib/sessiondescription.js
@@ -5,6 +5,12 @@ function RTCSessionDescription(descriptionInitDict) {
     this.type = descriptionInitDict.type;
     this.sdp = descriptionInitDict.sdp;
   }
+
+  this.toJSON = () => {
+    const { type, sdp } = this;
+
+    return { type, sdp };
+  };
 }
 
 module.exports = RTCSessionDescription;

--- a/lib/sessiondescription.js
+++ b/lib/sessiondescription.js
@@ -7,9 +7,12 @@ function RTCSessionDescription(descriptionInitDict) {
   }
 
   this.toJSON = () => {
-    const { type, sdp } = this;
+    const { sdp, type } = this;
 
-    return { type, sdp };
+    return {
+      sdp,
+      type
+    };
   };
 }
 


### PR DESCRIPTION
As MDN described, `RTCIceCandidate` and `RTCSessionDescription` on the web have `toJSON`, whose output is its own init value.

https://developer.mozilla.org/en-US/docs/Web/API/RTCSessionDescription/toJSON
https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/toJSON

However, `node-webrtc` does not implemented this yet, causing error as below:

https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js/issues/115#issuecomment-864861965

So I simply just put a `toJSON` method to them.