### PR TITLE
fix: build 32 bit windows version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ environment:
       platform: x64
       msvs_toolset: 15
       CHECK_REFLEXIVE: true
+    - nodejs_version: "8"
+      platform: x86
+      msvs_toolset: 15
+      CHECK_REFLEXIVE: true
 
 os: Visual Studio 2019
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "server-destroy": "^1.0.1",
     "simple-peer": "~9.7.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.5.2",
+    "tape": "^4.9.1",
     "temp": "^0.9.0",
     "travis-multirunner": "^4.3.0",
     "ws": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "server-destroy": "^1.0.1",
     "simple-peer": "~9.7.0",
     "tap-spec": "^5.0.0",
-    "tape": "^4.9.1",
+    "tape": "^5.5.2",
     "temp": "^0.9.0",
     "travis-multirunner": "^4.3.0",
     "ws": "^5.2.0"

--- a/scripts/build-appveyor.bat
+++ b/scripts/build-appveyor.bat
@@ -2,7 +2,7 @@
 SETLOCAL
 SET EL=0
 
-powershell Install-Product node $env:nodejs_version x64
+powershell Install-Product node $env:nodejs_version $env:platform
 IF %ERRORLEVEL% NEQ 0 GOTO ERROR
 
 ECHO npm install


### PR DESCRIPTION
Running Parallels on Apple M1 chips gives you an Arm version of Windows 11 by default which can't run 64 bit code so a 32 bit version is necessary.

Adds a new matrix entry with the `x86` platform (see [comment](https://github.com/node-webrtc/node-webrtc/issues/670#issuecomment-757504304) for context).

I'm not sure if anything else is necessary - @markandrus any ideas?