### PR TITLE
Specify lack of Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
     <tr>
       <td colspan="2" rowspan="2"></td>
       <th colspan="3">Linux</th>
-      <th>macOS</th>
+      <th colspan="2">macOS</th>
       <th>Windows</th>
     </tr>
     <tr>
       <th>armv7l</th>
       <th>arm64</th>
       <th>x64</th>
+      <th>arm64</th>
       <th>x64</th>
       <th>x64</th>
     </tr>
@@ -46,6 +47,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -54,6 +56,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -62,6 +65,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -70,6 +74,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -78,6 +83,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -86,6 +92,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center">✓</td>
         <td align="center">✓</td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -95,6 +102,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center"></td>
         <td align="center"></td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>
@@ -103,6 +111,7 @@ The following platforms are confirmed to work with node-webrtc and have prebuilt
         <td align="center"></td>
         <td align="center"></td>
         <td align="center">✓</td>
+      <td align="center"></td>
       <td align="center">✓</td>
       <td align="center">✓</td>
     </tr>


### PR DESCRIPTION
It has been 4 years since the last Intel mac has been released, so a large proportion of Mac users are using Apple Silicon macs.

Many developers have attempted to install this library on Apple Silicon and were unable to install. It should be made clear that Apple Silicon Macs aren't supported.

This can be seen by looking at the countless issues opened relating to this: #764 #760 #749 #729 #725 #718 #698 #695 #693 #680

P.s. I am happy to help contribute to whatever is needed to getting this working on Apple Silicon, just tell me what needs to be done.