### PR TITLE
docs: add node-webrtc-rust to See Also alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ See [node-webrtc/node-webrtc-examples](https://github.com/node-webrtc/node-webrt
 
 ## See Also
 
-If this package doesn't work for you, other alternatives that might suit your needs are [node-datachannel](https://github.com/murat-dogan/node-datachannel) and [werift](https://github.com/shinyoshiaki/werift-webrtc)
+If this package doesn't work for you, other alternatives that might suit your needs are [node-datachannel](https://github.com/murat-dogan/node-datachannel), [werift](https://github.com/shinyoshiaki/werift-webrtc), and [node-webrtc-rust](https://github.com/akirilyuk/node-webrtc-rust) (WebRTC + agentic voice STT/TTS in Node).


### PR DESCRIPTION
## Summary

Adds [node-webrtc-rust](https://github.com/akirilyuk/node-webrtc-rust) to the README **See Also** section alongside existing alternatives.

Different scope from `wrtc` — it targets **agentic voice workloads** (WebRTC transport + VAD/STT/TTS/barge-in in-process) rather than general spec-compliant bindings — but fits the same “if this package isn’t the right fit” audience.

Related: #773

## Test plan

- [x] One-line README change only
- [x] Link target verified: https://github.com/akirilyuk/node-webrtc-rust

Made with [Cursor](https://cursor.com)